### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exercism Perl 6 Track
 
-[![Build Status](https://travis-ci.org/exercism/perl6.svg?branch=master)](https://travis-ci.org/exercism/perl6) [![Gitter](https://badges.gitter.im/exercism/perl6.svg)](https://gitter.im/exercism/perl6?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Build Status](https://travis-ci.org/exercism/perl6.svg?branch=master)](https://travis-ci.org/exercism/perl6) [![Gitter](https://badges.gitter.im/exercism/perl.svg)](https://gitter.im/exercism/perl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Exercism exercises in Perl 6
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xPerl6
+# Exercism Perl 6 Track
 
-[![Build Status](https://travis-ci.org/exercism/xperl6.svg?branch=master)](https://travis-ci.org/exercism/xperl6) [![Gitter](https://badges.gitter.im/exercism/xperl.svg)](https://gitter.im/exercism/xperl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Build Status](https://travis-ci.org/exercism/perl6.svg?branch=master)](https://travis-ci.org/exercism/perl6) [![Gitter](https://badges.gitter.im/exercism/perl6.svg)](https://gitter.im/exercism/perl6?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Exercism exercises in Perl 6
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "perl6",
   "language": "Perl 6",
-  "repository": "https://github.com/exercism/xperl6",
+  "repository": "https://github.com/exercism/perl6",
   "checklist_issue": 30,
   "active": true,
   "test_pattern": ".*\\.t$",


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1