### PR TITLE
Use JSON formatted canonical-data

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -38,7 +38,7 @@ example: |
   }
 ```
 
-You must have `Template::Mustache`, `YAMLish`, and `Data::Dump` to run `exercise-gen.pl6`.
+You must have `Template::Mustache` and `YAMLish` to run `exercise-gen.pl6`.
 
 Note (2017-05-22): [YAMLish](http://modules.perl6.org/dist/YAMLish)
 is not yet feature complete, so some valid YAML files may not parse.

--- a/bin/exercise-gen.pl6
+++ b/bin/exercise-gen.pl6
@@ -2,8 +2,6 @@
 use v6;
 use Template::Mustache;
 use YAMLish;
-use Data::Dump;
-use JSON::Fast;
 
 my $base-dir = $?FILE.IO.resolve.parent.parent;
 my @exercises;
@@ -36,10 +34,7 @@ for @exercises -> $exercise {
   $_=.chomp when Str for @(%data.values);
 
   my $cdata = $base-dir.child("problem-specifications/exercises/$exercise/canonical-data.json");
-  if $cdata ~~ :f {
-    %data<cdata><json> = $cdata.slurp;
-    %data<cdata><perl> = Dump from-json(%data<cdata><json>), :!color;
-  }
+  if $cdata ~~ :f {%data<cdata><json> = $cdata.slurp}
 
   create-file "$exercise.t", 'test';
 

--- a/exercises/all-your-base/all-your-base.t
+++ b/exercises/all-your-base/all-your-base.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'AllYourBase';
 my $version = v2;
@@ -51,296 +52,203 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
-    {
-      description  => "single bit one to decimal".Str,
-      expected     => [
-        1.Int,
-      ],
-      input_base   => 2.Int,
-      input_digits => [
-        1.Int,
-      ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "binary to single decimal".Str,
-      expected     => [
-        5.Int,
-      ],
-      input_base   => 2.Int,
-      input_digits => [
-        1.Int,
-        0.Int,
-        1.Int,
-      ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "single decimal to binary".Str,
-      expected     => [
-        1.Int,
-        0.Int,
-        1.Int,
-      ],
-      input_base   => 10.Int,
-      input_digits => [
-        5.Int,
-      ],
-      output_base  => 2.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "binary to multiple decimal".Str,
-      expected     => [
-        4.Int,
-        2.Int,
-      ],
-      input_base   => 2.Int,
-      input_digits => [
-        1.Int,
-        0.Int,
-        1.Int,
-        0.Int,
-        1.Int,
-        0.Int,
-      ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "decimal to binary".Str,
-      expected     => [
-        1.Int,
-        0.Int,
-        1.Int,
-        0.Int,
-        1.Int,
-        0.Int,
-      ],
-      input_base   => 10.Int,
-      input_digits => [
-        4.Int,
-        2.Int,
-      ],
-      output_base  => 2.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "trinary to hexadecimal".Str,
-      expected     => [
-        2.Int,
-        10.Int,
-      ],
-      input_base   => 3.Int,
-      input_digits => [
-        1.Int,
-        1.Int,
-        2.Int,
-        0.Int,
-      ],
-      output_base  => 16.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "hexadecimal to trinary".Str,
-      expected     => [
-        1.Int,
-        1.Int,
-        2.Int,
-        0.Int,
-      ],
-      input_base   => 16.Int,
-      input_digits => [
-        2.Int,
-        10.Int,
-      ],
-      output_base  => 3.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "15-bit integer".Str,
-      expected     => [
-        6.Int,
-        10.Int,
-        45.Int,
-      ],
-      input_base   => 97.Int,
-      input_digits => [
-        3.Int,
-        46.Int,
-        60.Int,
-      ],
-      output_base  => 73.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "empty list".Str,
-      expected     => (Any),
-      input_base   => 2.Int,
-      input_digits => [ ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "single zero".Str,
-      expected     => (Any),
-      input_base   => 10.Int,
-      input_digits => [
-        0.Int,
-      ],
-      output_base  => 2.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "multiple zeros".Str,
-      expected     => (Any),
-      input_base   => 10.Int,
-      input_digits => [
-        0.Int,
-        0.Int,
-        0.Int,
-      ],
-      output_base  => 2.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "leading zeros".Str,
-      expected     => (Any),
-      input_base   => 7.Int,
-      input_digits => [
-        0.Int,
-        6.Int,
-        0.Int,
-      ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "first base is one".Str,
-      expected     => (Any),
-      input_base   => 1.Int,
-      input_digits => [ ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "first base is zero".Str,
-      expected     => (Any),
-      input_base   => 0.Int,
-      input_digits => [ ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "first base is negative".Str,
-      expected     => (Any),
-      input_base   => -2.Int,
-      input_digits => [
-        1.Int,
-      ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "negative digit".Str,
-      expected     => (Any),
-      input_base   => 2.Int,
-      input_digits => [
-        1.Int,
-        -1.Int,
-        1.Int,
-        0.Int,
-        1.Int,
-        0.Int,
-      ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "invalid positive digit".Str,
-      expected     => (Any),
-      input_base   => 2.Int,
-      input_digits => [
-        1.Int,
-        2.Int,
-        1.Int,
-        0.Int,
-        1.Int,
-        0.Int,
-      ],
-      output_base  => 10.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "second base is one".Str,
-      expected     => (Any),
-      input_base   => 2.Int,
-      input_digits => [
-        1.Int,
-        0.Int,
-        1.Int,
-        0.Int,
-        1.Int,
-        0.Int,
-      ],
-      output_base  => 1.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "second base is zero".Str,
-      expected     => (Any),
-      input_base   => 10.Int,
-      input_digits => [
-        7.Int,
-      ],
-      output_base  => 0.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "second base is negative".Str,
-      expected     => (Any),
-      input_base   => 2.Int,
-      input_digits => [
-        1.Int,
-      ],
-      output_base  => -7.Int,
-      property     => "rebase".Str,
-    },
-    {
-      description  => "both bases are negative".Str,
-      expected     => (Any),
-      input_base   => -2.Int,
-      input_digits => [
-        1.Int,
-      ],
-      output_base  => -7.Int,
-      property     => "rebase".Str,
-    },
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "all-your-base",
+  "version": "1.1.0",
+  "comments": [
+    "It's up to each track do decide:",
+    "",
+    "1. What's the canonical representation of zero?",
+    " - []?",
+    " - [0]?",
+    "",
+    "2. What representations of zero are allowed?",
+    " - []?",
+    " - [0]?",
+    " - [0,0]?",
+    "",
+    "3. Are leading zeroes allowed?",
+    "",
+    "4. How should invalid input be handled?",
+    "",
+    "All the undefined cases are marked as null.",
+    "",
+    "All your numeric-base are belong to [2..]. :)"
   ],
-  comments => [
-    "It's up to each track do decide:".Str,
-    "".Str,
-    "1. What's the canonical representation of zero?".Str,
-    " - []?".Str,
-    " - [0]?".Str,
-    "".Str,
-    "2. What representations of zero are allowed?".Str,
-    " - []?".Str,
-    " - [0]?".Str,
-    " - [0,0]?".Str,
-    "".Str,
-    "3. Are leading zeroes allowed?".Str,
-    "".Str,
-    "4. How should invalid input be handled?".Str,
-    "".Str,
-    "All the undefined cases are marked as null.".Str,
-    "".Str,
-    "All your numeric-base are belong to [2..]. :)".Str,
-  ],
-  exercise => "all-your-base".Str,
-  version  => "1.1.0".Str,
-} }
+  "cases": [
+    {
+      "description": "single bit one to decimal",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1],
+      "output_base": 10,
+      "expected": [1]
+    },
+    {
+      "description": "binary to single decimal",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, 0, 1],
+      "output_base": 10,
+      "expected": [5]
+    },
+    {
+      "description": "single decimal to binary",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [5],
+      "output_base": 2,
+      "expected": [1, 0, 1]
+    },
+    {
+      "description": "binary to multiple decimal",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, 0, 1, 0, 1, 0],
+      "output_base": 10,
+      "expected": [4, 2]
+    },
+    {
+      "description": "decimal to binary",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [4, 2],
+      "output_base": 2,
+      "expected": [1, 0, 1, 0, 1, 0]
+    },
+    {
+      "description": "trinary to hexadecimal",
+      "property": "rebase",
+      "input_base": 3,
+      "input_digits": [1, 1, 2, 0],
+      "output_base": 16,
+      "expected": [2, 10]
+    },
+    {
+      "description": "hexadecimal to trinary",
+      "property": "rebase",
+      "input_base": 16,
+      "input_digits": [2, 10],
+      "output_base": 3,
+      "expected": [1, 1, 2, 0]
+    },
+    {
+      "description": "15-bit integer",
+      "property": "rebase",
+      "input_base": 97,
+      "input_digits": [3, 46, 60],
+      "output_base": 73,
+      "expected": [6, 10, 45]
+    },
+    {
+      "description": "empty list",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "single zero",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [0],
+      "output_base": 2,
+      "expected": null
+    },
+    {
+      "description": "multiple zeros",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [0, 0, 0],
+      "output_base": 2,
+      "expected": null
+    },
+    {
+      "description": "leading zeros",
+      "property": "rebase",
+      "input_base": 7,
+      "input_digits": [0, 6, 0],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "first base is one",
+      "property": "rebase",
+      "input_base": 1,
+      "input_digits": [],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "first base is zero",
+      "property": "rebase",
+      "input_base": 0,
+      "input_digits": [],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "first base is negative",
+      "property": "rebase",
+      "input_base": -2,
+      "input_digits": [1],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "negative digit",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, -1, 1, 0, 1, 0],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "invalid positive digit",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, 2, 1, 0, 1, 0],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "second base is one",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, 0, 1, 0, 1, 0],
+      "output_base": 1,
+      "expected": null
+    },
+    {
+      "description": "second base is zero",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [7],
+      "output_base": 0,
+      "expected": null
+    },
+    {
+      "description": "second base is negative",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1],
+      "output_base": -7,
+      "expected": null
+    },
+    {
+      "description": "both bases are negative",
+      "property": "rebase",
+      "input_base": -2,
+      "input_digits": [1],
+      "output_base": -7,
+      "expected": null
+    }
+  ]
+}
+
+END
+}

--- a/exercises/allergies/allergies.t
+++ b/exercises/allergies/allergies.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Allergies';
 my $version = v1;
@@ -46,167 +47,158 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "allergies",
+  "version": "1.0.0",
+  "cases": [
     {
-      cases       => [
-        {
-          description => "no allergies means not allergic".Str,
-          expected    => [
-            {
-              result    => Bool::False.Bool,
-              substance => "peanuts".Str,
-            },
-            {
-              result    => Bool::False.Bool,
-              substance => "cats".Str,
-            },
-            {
-              result    => Bool::False.Bool,
-              substance => "strawberries".Str,
-            },
-          ],
-          property    => "allergicTo".Str,
-          score       => 0.Int,
-        },
-        {
-          description => "is allergic to eggs".Str,
-          expected    => [
-            {
-              result    => Bool::True.Bool,
-              substance => "eggs".Str,
-            },
-          ],
-          property    => "allergicTo".Str,
-          score       => 1.Int,
-        },
-        {
-          description => "allergic to eggs in addition to other stuff".Str,
-          expected    => [
-            {
-              result    => Bool::True.Bool,
-              substance => "eggs".Str,
-            },
-            {
-              result    => Bool::True.Bool,
-              substance => "shellfish".Str,
-            },
-            {
-              result    => Bool::False.Bool,
-              substance => "strawberries".Str,
-            },
-          ],
-          property    => "allergicTo".Str,
-          score       => 5.Int,
-        },
+      "description": "allergicTo",
+      "comments": [
+        "Given a number and a substance, indicate whether Tom is allergic ",
+        "to that substance.",
+        "Test cases for this method involve more than one assertion.",
+        "Each case in 'expected' specifies what the method should return for",
+        "the given substance."
       ],
-      comments    => [
-        "Given a number and a substance, indicate whether Tom is allergic ".Str,
-        "to that substance.".Str,
-        "Test cases for this method involve more than one assertion.".Str,
-        "Each case in 'expected' specifies what the method should return for".Str,
-        "the given substance.".Str,
-      ],
-      description => "allergicTo".Str,
+      "cases": [
+        {
+          "description": "no allergies means not allergic",
+          "property": "allergicTo",
+          "score": 0,
+          "expected": [
+            {
+              "substance": "peanuts",
+              "result": false
+            },
+            {
+              "substance": "cats",
+              "result": false
+            },
+            {
+              "substance": "strawberries",
+              "result": false
+            }
+          ]
+        },
+        {
+          "description": "is allergic to eggs",
+          "property": "allergicTo",
+          "score": 1,
+          "expected": [
+            {
+              "substance": "eggs",
+              "result": true
+            }
+          ]
+        },
+        {
+          "description": "allergic to eggs in addition to other stuff",
+          "property": "allergicTo",
+          "score": 5,
+          "expected": [
+            {
+              "substance": "eggs",
+              "result": true
+            },
+            {
+              "substance": "shellfish",
+              "result": true
+            },
+            {
+              "substance": "strawberries",
+              "result": false
+            }
+          ]
+        }
+      ]
     },
     {
-      cases       => [
-        {
-          description => "no allergies at all".Str,
-          expected    => [ ],
-          property    => "list".Str,
-          score       => 0.Int,
-        },
-        {
-          description => "allergic to just eggs".Str,
-          expected    => [
-            "eggs".Str,
-          ],
-          property    => "list".Str,
-          score       => 1.Int,
-        },
-        {
-          description => "allergic to just peanuts".Str,
-          expected    => [
-            "peanuts".Str,
-          ],
-          property    => "list".Str,
-          score       => 2.Int,
-        },
-        {
-          description => "allergic to just strawberries".Str,
-          expected    => [
-            "strawberries".Str,
-          ],
-          property    => "list".Str,
-          score       => 8.Int,
-        },
-        {
-          description => "allergic to eggs and peanuts".Str,
-          expected    => [
-            "eggs".Str,
-            "peanuts".Str,
-          ],
-          property    => "list".Str,
-          score       => 3.Int,
-        },
-        {
-          description => "allergic to more than eggs but not peanuts".Str,
-          expected    => [
-            "eggs".Str,
-            "shellfish".Str,
-          ],
-          property    => "list".Str,
-          score       => 5.Int,
-        },
-        {
-          description => "allergic to lots of stuff".Str,
-          expected    => [
-            "strawberries".Str,
-            "tomatoes".Str,
-            "chocolate".Str,
-            "pollen".Str,
-            "cats".Str,
-          ],
-          property    => "list".Str,
-          score       => 248.Int,
-        },
-        {
-          description => "allergic to everything".Str,
-          expected    => [
-            "eggs".Str,
-            "peanuts".Str,
-            "shellfish".Str,
-            "strawberries".Str,
-            "tomatoes".Str,
-            "chocolate".Str,
-            "pollen".Str,
-            "cats".Str,
-          ],
-          property    => "list".Str,
-          score       => 255.Int,
-        },
-        {
-          description => "ignore non allergen score parts".Str,
-          expected    => [
-            "eggs".Str,
-            "shellfish".Str,
-            "strawberries".Str,
-            "tomatoes".Str,
-            "chocolate".Str,
-            "pollen".Str,
-            "cats".Str,
-          ],
-          property    => "list".Str,
-          score       => 509.Int,
-        },
+      "description": "list",
+      "comments": [
+        "Given a number, list all things Tom is allergic to"
       ],
-      comments    => [
-        "Given a number, list all things Tom is allergic to".Str,
-      ],
-      description => "list".Str,
-    },
-  ],
-  exercise => "allergies".Str,
-  version  => "1.0.0".Str,
-} }
+      "cases": [
+        {
+          "description": "no allergies at all",
+          "property": "list",
+          "score": 0,
+          "expected": []
+        },
+        {
+          "description": "allergic to just eggs",
+          "property": "list",
+          "score": 1,
+          "expected": ["eggs"]
+        },
+        {
+          "description": "allergic to just peanuts",
+          "property": "list",
+          "score": 2,
+          "expected": ["peanuts"]
+        },
+        {
+          "description": "allergic to just strawberries",
+          "property": "list",
+          "score": 8,
+          "expected": ["strawberries"]
+        },
+        {
+          "description": "allergic to eggs and peanuts",
+          "property": "list",
+          "score": 3,
+          "expected": ["eggs", "peanuts"]
+        },
+        {
+          "description": "allergic to more than eggs but not peanuts",
+          "property": "list",
+          "score": 5,
+          "expected": ["eggs", "shellfish"]
+        },
+        {
+          "description": "allergic to lots of stuff",
+          "property": "list",
+          "score": 248,
+          "expected": [ "strawberries",
+                        "tomatoes",
+                        "chocolate",
+                        "pollen",
+                        "cats"
+                      ]
+        },
+        {
+          "description": "allergic to everything",
+          "property": "list",
+          "score": 255,
+          "expected": [ "eggs",
+                        "peanuts",
+                        "shellfish",
+                        "strawberries",
+                        "tomatoes",
+                        "chocolate",
+                        "pollen",
+                        "cats"
+                      ]
+        },
+        {
+          "description": "ignore non allergen score parts",
+          "property": "list",
+          "score": 509,
+          "expected": [ "eggs",
+                        "shellfish",
+                        "strawberries",
+                        "tomatoes",
+                        "chocolate",
+                        "pollen",
+                        "cats"
+                      ]
+        }
+      ]
+    }
+  ]
+}
+
+END
+}

--- a/exercises/anagram/anagram.t
+++ b/exercises/anagram/anagram.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Anagram';
 my $version = v1;
@@ -31,206 +32,139 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
-    {
-      candidates  => [
-        "hello".Str,
-        "world".Str,
-        "zombies".Str,
-        "pants".Str,
-      ],
-      description => "no matches".Str,
-      expected    => [ ],
-      property    => "anagrams".Str,
-      subject     => "diaper".Str,
-    },
-    {
-      candidates  => [
-        "tan".Str,
-        "stand".Str,
-        "at".Str,
-      ],
-      description => "detects simple anagram".Str,
-      expected    => [
-        "tan".Str,
-      ],
-      property    => "anagrams".Str,
-      subject     => "ant".Str,
-    },
-    {
-      candidates  => [
-        "eagle".Str,
-      ],
-      description => "does not detect false positives".Str,
-      expected    => [ ],
-      property    => "anagrams".Str,
-      subject     => "galea".Str,
-    },
-    {
-      candidates  => [
-        "stream".Str,
-        "pigeon".Str,
-        "maters".Str,
-      ],
-      description => "detects two anagrams".Str,
-      expected    => [
-        "stream".Str,
-        "maters".Str,
-      ],
-      property    => "anagrams".Str,
-      subject     => "master".Str,
-    },
-    {
-      candidates  => [
-        "dog".Str,
-        "goody".Str,
-      ],
-      description => "does not detect anagram subsets".Str,
-      expected    => [ ],
-      property    => "anagrams".Str,
-      subject     => "good".Str,
-    },
-    {
-      candidates  => [
-        "enlists".Str,
-        "google".Str,
-        "inlets".Str,
-        "banana".Str,
-      ],
-      description => "detects anagram".Str,
-      expected    => [
-        "inlets".Str,
-      ],
-      property    => "anagrams".Str,
-      subject     => "listen".Str,
-    },
-    {
-      candidates  => [
-        "gallery".Str,
-        "ballerina".Str,
-        "regally".Str,
-        "clergy".Str,
-        "largely".Str,
-        "leading".Str,
-      ],
-      description => "detects three anagrams".Str,
-      expected    => [
-        "gallery".Str,
-        "regally".Str,
-        "largely".Str,
-      ],
-      property    => "anagrams".Str,
-      subject     => "allergy".Str,
-    },
-    {
-      candidates  => [
-        "corn".Str,
-        "dark".Str,
-        "Corn".Str,
-        "rank".Str,
-        "CORN".Str,
-        "cron".Str,
-        "park".Str,
-      ],
-      description => "does not detect identical words".Str,
-      expected    => [
-        "cron".Str,
-      ],
-      property    => "anagrams".Str,
-      subject     => "corn".Str,
-    },
-    {
-      candidates  => [
-        "last".Str,
-      ],
-      description => "does not detect non-anagrams with identical checksum".Str,
-      expected    => [ ],
-      property    => "anagrams".Str,
-      subject     => "mass".Str,
-    },
-    {
-      candidates  => [
-        "cashregister".Str,
-        "Carthorse".Str,
-        "radishes".Str,
-      ],
-      description => "detects anagrams case-insensitively".Str,
-      expected    => [
-        "Carthorse".Str,
-      ],
-      property    => "anagrams".Str,
-      subject     => "Orchestra".Str,
-    },
-    {
-      candidates  => [
-        "cashregister".Str,
-        "carthorse".Str,
-        "radishes".Str,
-      ],
-      description => "detects anagrams using case-insensitive subject".Str,
-      expected    => [
-        "carthorse".Str,
-      ],
-      property    => "anagrams".Str,
-      subject     => "Orchestra".Str,
-    },
-    {
-      candidates  => [
-        "cashregister".Str,
-        "Carthorse".Str,
-        "radishes".Str,
-      ],
-      description => "detects anagrams using case-insensitive possible matches".Str,
-      expected    => [
-        "Carthorse".Str,
-      ],
-      property    => "anagrams".Str,
-      subject     => "orchestra".Str,
-    },
-    {
-      candidates  => [
-        "Banana".Str,
-      ],
-      description => "does not detect a word as its own anagram".Str,
-      expected    => [ ],
-      property    => "anagrams".Str,
-      subject     => "banana".Str,
-    },
-    {
-      candidates  => [
-        "go Go GO".Str,
-      ],
-      description => "does not detect a anagram if the original word is repeated".Str,
-      expected    => [ ],
-      property    => "anagrams".Str,
-      subject     => "go".Str,
-    },
-    {
-      candidates  => [
-        "patter".Str,
-      ],
-      description => "anagrams must use all letters exactly once".Str,
-      expected    => [ ],
-      property    => "anagrams".Str,
-      subject     => "tapper".Str,
-    },
-    {
-      candidates  => [
-        "Banana".Str,
-      ],
-      description => "capital word is not own anagram".Str,
-      expected    => [ ],
-      property    => "anagrams".Str,
-      subject     => "BANANA".Str,
-    },
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "anagram",
+  "version": "1.0.1",
+  "comments": [
+    "The string argument cases possible matches are passed in as",
+    "individual arguments rather than arrays. Languages can include",
+    "these string argument cases if passing individual arguments is",
+    "idiomatic in that language."
   ],
-  comments => [
-    "The string argument cases possible matches are passed in as".Str,
-    "individual arguments rather than arrays. Languages can include".Str,
-    "these string argument cases if passing individual arguments is".Str,
-    "idiomatic in that language.".Str,
-  ],
-  exercise => "anagram".Str,
-  version  => "1.0.1".Str,
-} }
+  "cases": [
+    {
+      "description": "no matches",
+      "property": "anagrams",
+      "subject": "diaper",
+      "candidates": ["hello", "world", "zombies", "pants"],
+      "expected": []
+    },
+    {
+      "description": "detects simple anagram",
+      "property": "anagrams",
+      "subject": "ant",
+      "candidates": ["tan", "stand", "at"],
+      "expected": ["tan"]
+    },
+    {
+      "description": "does not detect false positives",
+      "property": "anagrams",
+      "subject": "galea",
+      "candidates": ["eagle"],
+      "expected": []
+    },
+    {
+      "description": "detects two anagrams",
+      "property": "anagrams",
+      "subject": "master",
+      "candidates": ["stream", "pigeon", "maters"],
+      "expected": ["stream", "maters"]
+    },
+    {
+      "description": "does not detect anagram subsets",
+      "property": "anagrams",
+      "subject": "good",
+      "candidates": ["dog", "goody"],
+      "expected": []
+    },
+    {
+      "description": "detects anagram",
+      "property": "anagrams",
+      "subject": "listen",
+      "candidates": ["enlists", "google", "inlets", "banana"],
+      "expected": ["inlets"]
+    },
+    {
+      "description": "detects three anagrams",
+      "property": "anagrams",
+      "subject": "allergy",
+      "candidates": [ "gallery",
+                      "ballerina",
+                      "regally",
+                      "clergy",
+                      "largely",
+                      "leading"
+                    ],
+      "expected": ["gallery", "regally", "largely"]
+    },
+    {
+      "description": "does not detect identical words",
+      "property": "anagrams",
+      "subject": "corn",
+      "candidates": ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"],
+      "expected": ["cron"]
+    },
+    {
+      "description": "does not detect non-anagrams with identical checksum",
+      "property": "anagrams",
+      "subject": "mass",
+      "candidates": ["last"],
+      "expected": []
+    },
+    {
+      "description": "detects anagrams case-insensitively",
+      "property": "anagrams",
+      "subject": "Orchestra",
+      "candidates": ["cashregister", "Carthorse", "radishes"],
+      "expected": ["Carthorse"]
+    },
+    {
+      "description": "detects anagrams using case-insensitive subject",
+      "property": "anagrams",
+      "subject": "Orchestra",
+      "candidates": ["cashregister", "carthorse", "radishes"],
+      "expected": ["carthorse"]
+    },
+    {
+      "description": "detects anagrams using case-insensitive possible matches",
+      "property": "anagrams",
+      "subject": "orchestra",
+      "candidates": ["cashregister", "Carthorse", "radishes"],
+      "expected": ["Carthorse"]
+    },
+    {
+      "description": "does not detect a word as its own anagram",
+      "property": "anagrams",
+      "subject": "banana",
+      "candidates": ["Banana"],
+      "expected": []
+    },
+    {
+      "description": "does not detect a anagram if the original word is repeated",
+      "property": "anagrams",
+      "subject": "go",
+      "candidates": ["go Go GO"],
+      "expected": []
+    },
+    {
+      "description": "anagrams must use all letters exactly once",
+      "property": "anagrams",
+      "subject": "tapper",
+      "candidates": ["patter"],
+      "expected": []
+    },
+    {
+      "description": "capital word is not own anagram",
+      "property": "anagrams",
+      "subject": "BANANA",
+      "candidates": ["Banana"],
+      "expected": []
+    }
+  ]
+}
+
+END
+}

--- a/exercises/atbash-cipher/atbash-cipher.t
+++ b/exercises/atbash-cipher/atbash-cipher.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'AtbashCipher';
 my $version = v1;
@@ -38,102 +39,104 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "atbash-cipher",
+  "version": "1.0.0",
+  "comments": [
+    "The tests are divided into two groups: ",
+    "* Encoding from English to atbash cipher",
+    "* Decoding from atbash cipher to all-lowercase-mashed-together English"
+  ],
+  "cases": [
     {
-      cases       => [
+      "description": "encode",
+      "comments": [ "Test encoding from English to atbash" ],
+      "cases": [
         {
-          description => "encode yes".Str,
-          expected    => "bvh".Str,
-          phrase      => "yes".Str,
-          property    => "encode".Str,
+          "description": "encode yes",
+          "property": "encode",
+          "phrase": "yes",
+          "expected": "bvh"
         },
         {
-          description => "encode no".Str,
-          expected    => "ml".Str,
-          phrase      => "no".Str,
-          property    => "encode".Str,
+          "description": "encode no",
+          "property": "encode",
+          "phrase": "no",
+          "expected": "ml"
         },
         {
-          description => "encode OMG".Str,
-          expected    => "lnt".Str,
-          phrase      => "OMG".Str,
-          property    => "encode".Str,
+          "description": "encode OMG",
+          "property": "encode",
+          "phrase": "OMG",
+          "expected": "lnt"
         },
         {
-          description => "encode spaces".Str,
-          expected    => "lnt".Str,
-          phrase      => "O M G".Str,
-          property    => "encode".Str,
+          "description": "encode spaces",
+          "property": "encode",
+          "phrase": "O M G",
+          "expected": "lnt"
         },
         {
-          description => "encode mindblowingly".Str,
-          expected    => "nrmwy oldrm tob".Str,
-          phrase      => "mindblowingly".Str,
-          property    => "encode".Str,
+          "description": "encode mindblowingly",
+          "property": "encode",
+          "phrase": "mindblowingly",
+          "expected": "nrmwy oldrm tob"
         },
         {
-          description => "encode numbers".Str,
-          expected    => "gvhgr mt123 gvhgr mt".Str,
-          phrase      => "Testing,1 2 3, testing.".Str,
-          property    => "encode".Str,
+          "description": "encode numbers",
+          "property": "encode",
+          "phrase": "Testing,1 2 3, testing.",
+          "expected": "gvhgr mt123 gvhgr mt"
         },
         {
-          description => "encode deep thought".Str,
-          expected    => "gifgs rhurx grlm".Str,
-          phrase      => "Truth is fiction.".Str,
-          property    => "encode".Str,
+          "description": "encode deep thought",
+          "property": "encode",
+          "phrase": "Truth is fiction.",
+          "expected": "gifgs rhurx grlm"
         },
         {
-          description => "encode all the letters".Str,
-          expected    => "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt".Str,
-          phrase      => "The quick brown fox jumps over the lazy dog.".Str,
-          property    => "encode".Str,
-        },
-      ],
-      comments    => [
-        "Test encoding from English to atbash".Str,
-      ],
-      description => "encode".Str,
+          "description": "encode all the letters",
+          "property": "encode",
+          "phrase": "The quick brown fox jumps over the lazy dog.",
+          "expected": "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+        }
+      ]
     },
     {
-      cases       => [
+      "description": "decode",
+      "comments": [ "Test decoding from atbash to English" ],
+      "cases": [
         {
-          description => "decode exercism".Str,
-          expected    => "exercism".Str,
-          phrase      => "vcvix rhn".Str,
-          property    => "decode".Str,
+          "description": "decode exercism",
+          "property": "decode",
+          "phrase": "vcvix rhn",
+          "expected": "exercism"
         },
         {
-          description => "decode a sentence".Str,
-          expected    => "anobstacleisoftenasteppingstone".Str,
-          phrase      => "zmlyh gzxov rhlug vmzhg vkkrm thglm v".Str,
-          property    => "decode".Str,
+          "description": "decode a sentence",
+          "property": "decode",
+          "phrase": "zmlyh gzxov rhlug vmzhg vkkrm thglm v",
+          "expected": "anobstacleisoftenasteppingstone"
         },
         {
-          description => "decode numbers".Str,
-          expected    => "testing123testing".Str,
-          phrase      => "gvhgr mt123 gvhgr mt".Str,
-          property    => "decode".Str,
+          "description": "decode numbers",
+          "property": "decode",
+          "phrase": "gvhgr mt123 gvhgr mt",
+          "expected": "testing123testing"
         },
         {
-          description => "decode all the letters".Str,
-          expected    => "thequickbrownfoxjumpsoverthelazydog".Str,
-          phrase      => "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt".Str,
-          property    => "decode".Str,
-        },
-      ],
-      comments    => [
-        "Test decoding from atbash to English".Str,
-      ],
-      description => "decode".Str,
-    },
-  ],
-  comments => [
-    "The tests are divided into two groups: ".Str,
-    "* Encoding from English to atbash cipher".Str,
-    "* Decoding from atbash cipher to all-lowercase-mashed-together English".Str,
-  ],
-  exercise => "atbash-cipher".Str,
-  version  => "1.0.0".Str,
-} }
+          "description": "decode all the letters",
+          "property": "decode",
+          "phrase": "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt",
+          "expected": "thequickbrownfoxjumpsoverthelazydog"
+        }
+      ]
+    }
+  ]
+}
+
+END
+}

--- a/exercises/bob/bob.t
+++ b/exercises/bob/bob.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname; #`[Look for the module inside the same directory as this test file.]
+use JSON::Fast;
 
 my $exercise = 'Bob'; #`[The name of this exercise.]
 my $version = v1; #`[The version we will be matching against the exercise.]
@@ -43,159 +44,165 @@ done-testing; #`[There are no more tests after this :)]
 
 #`['INIT' is a phaser, it makes sure that the test data is available before everything else
 starts running (otherwise we'd have to shove the test data into the middle of the file!)]
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "bob",
+  "version": "1.0.0",
+  "cases": [
     {
-      description => "stating something".Str,
-      expected    => "Whatever.".Str,
-      input       => "Tom-ay-to, tom-aaaah-to.".Str,
-      property    => "response".Str,
+      "description": "stating something",
+      "property": "response",
+      "input": "Tom-ay-to, tom-aaaah-to.",
+      "expected": "Whatever."
     },
     {
-      description => "shouting".Str,
-      expected    => "Whoa, chill out!".Str,
-      input       => "WATCH OUT!".Str,
-      property    => "response".Str,
+      "description": "shouting",
+      "property": "response",
+      "input": "WATCH OUT!",
+      "expected": "Whoa, chill out!"
     },
     {
-      description => "shouting gibberish".Str,
-      expected    => "Whoa, chill out!".Str,
-      input       => "FCECDFCAAB".Str,
-      property    => "response".Str,
+      "description": "shouting gibberish",
+      "property": "response",
+      "input": "FCECDFCAAB",
+      "expected": "Whoa, chill out!"
     },
     {
-      description => "asking a question".Str,
-      expected    => "Sure.".Str,
-      input       => "Does this cryogenic chamber make me look fat?".Str,
-      property    => "response".Str,
+      "description": "asking a question",
+      "property": "response",
+      "input": "Does this cryogenic chamber make me look fat?",
+      "expected": "Sure."
     },
     {
-      description => "asking a numeric question".Str,
-      expected    => "Sure.".Str,
-      input       => "You are, what, like 15?".Str,
-      property    => "response".Str,
+      "description": "asking a numeric question",
+      "property": "response",
+      "input": "You are, what, like 15?",
+      "expected": "Sure."
     },
     {
-      description => "asking gibberish".Str,
-      expected    => "Sure.".Str,
-      input       => "fffbbcbeab?".Str,
-      property    => "response".Str,
+      "description": "asking gibberish",
+      "property": "response",
+      "input": "fffbbcbeab?",
+      "expected": "Sure."
     },
     {
-      description => "talking forcefully".Str,
-      expected    => "Whatever.".Str,
-      input       => "Let's go make out behind the gym!".Str,
-      property    => "response".Str,
+      "description": "talking forcefully",
+      "property": "response",
+      "input": "Let's go make out behind the gym!",
+      "expected": "Whatever."
     },
     {
-      description => "using acronyms in regular speech".Str,
-      expected    => "Whatever.".Str,
-      input       => "It's OK if you don't want to go to the DMV.".Str,
-      property    => "response".Str,
+      "description": "using acronyms in regular speech",
+      "property": "response",
+      "input": "It's OK if you don't want to go to the DMV.",
+      "expected": "Whatever."
     },
     {
-      description => "forceful question".Str,
-      expected    => "Whoa, chill out!".Str,
-      input       => "WHAT THE HELL WERE YOU THINKING?".Str,
-      property    => "response".Str,
+      "description": "forceful question",
+      "property": "response",
+      "input": "WHAT THE HELL WERE YOU THINKING?",
+      "expected": "Whoa, chill out!"
     },
     {
-      description => "shouting numbers".Str,
-      expected    => "Whoa, chill out!".Str,
-      input       => "1, 2, 3 GO!".Str,
-      property    => "response".Str,
+      "description": "shouting numbers",
+      "property": "response",
+      "input": "1, 2, 3 GO!",
+      "expected": "Whoa, chill out!"
     },
     {
-      description => "only numbers".Str,
-      expected    => "Whatever.".Str,
-      input       => "1, 2, 3".Str,
-      property    => "response".Str,
+      "description": "only numbers",
+      "property": "response",
+      "input": "1, 2, 3",
+      "expected": "Whatever."
     },
     {
-      description => "question with only numbers".Str,
-      expected    => "Sure.".Str,
-      input       => "4?".Str,
-      property    => "response".Str,
+      "description": "question with only numbers",
+      "property": "response",
+      "input": "4?",
+      "expected": "Sure."
     },
     {
-      description => "shouting with special characters".Str,
-      expected    => "Whoa, chill out!".Str,
-      input       => "ZOMG THE \%^*\@#\$(*^ ZOMBIES ARE COMING!!11!!1!".Str,
-      property    => "response".Str,
+      "description": "shouting with special characters",
+      "property": "response",
+      "input": "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!",
+      "expected": "Whoa, chill out!"
     },
     {
-      description => "shouting with no exclamation mark".Str,
-      expected    => "Whoa, chill out!".Str,
-      input       => "I HATE YOU".Str,
-      property    => "response".Str,
+      "description": "shouting with no exclamation mark",
+      "property": "response",
+      "input": "I HATE YOU",
+      "expected": "Whoa, chill out!"
     },
     {
-      description => "statement containing question mark".Str,
-      expected    => "Whatever.".Str,
-      input       => "Ending with ? means a question.".Str,
-      property    => "response".Str,
+      "description": "statement containing question mark",
+      "property": "response",
+      "input": "Ending with ? means a question.",
+      "expected": "Whatever."
     },
     {
-      description => "non-letters with question".Str,
-      expected    => "Sure.".Str,
-      input       => ":) ?".Str,
-      property    => "response".Str,
+      "description": "non-letters with question",
+      "property": "response",
+      "input": ":) ?",
+      "expected": "Sure."
     },
     {
-      description => "prattling on".Str,
-      expected    => "Sure.".Str,
-      input       => "Wait! Hang on. Are you going to be OK?".Str,
-      property    => "response".Str,
+      "description": "prattling on",
+      "property": "response",
+      "input": "Wait! Hang on. Are you going to be OK?",
+      "expected": "Sure."
     },
     {
-      description => "silence".Str,
-      expected    => "Fine. Be that way!".Str,
-      input       => "".Str,
-      property    => "response".Str,
+      "description": "silence",
+      "property": "response",
+      "input": "",
+      "expected": "Fine. Be that way!"
     },
     {
-      description => "prolonged silence".Str,
-      expected    => "Fine. Be that way!".Str,
-      input       => "          ".Str,
-      property    => "response".Str,
+      "description": "prolonged silence",
+      "property": "response",
+      "input": "          ",
+      "expected": "Fine. Be that way!"
     },
     {
-      description => "alternate silence".Str,
-      expected    => "Fine. Be that way!".Str,
-      input       => "\t\t\t\t\t\t\t\t\t\t".Str,
-      property    => "response".Str,
+      "description": "alternate silence",
+      "property": "response",
+      "input": "\t\t\t\t\t\t\t\t\t\t",
+      "expected": "Fine. Be that way!"
     },
     {
-      description => "multiple line question".Str,
-      expected    => "Whatever.".Str,
-      input       => "\nDoes this cryogenic chamber make me look fat?\nno".Str,
-      property    => "response".Str,
+      "description": "multiple line question",
+      "property": "response",
+      "input": "\nDoes this cryogenic chamber make me look fat?\nno",
+      "expected": "Whatever."
     },
     {
-      description => "starting with whitespace".Str,
-      expected    => "Whatever.".Str,
-      input       => "         hmmmmmmm...".Str,
-      property    => "response".Str,
+      "description": "starting with whitespace",
+      "property": "response",
+      "input": "         hmmmmmmm...",
+      "expected": "Whatever."
     },
     {
-      description => "ending with whitespace".Str,
-      expected    => "Sure.".Str,
-      input       => "Okay if like my  spacebar  quite a bit?   ".Str,
-      property    => "response".Str,
+      "description": "ending with whitespace",
+      "property": "response",
+      "input": "Okay if like my  spacebar  quite a bit?   ",
+      "expected": "Sure."
     },
     {
-      description => "other whitespace".Str,
-      expected    => "Fine. Be that way!".Str,
-      input       => "\n\r \t".Str,
-      property    => "response".Str,
+      "description": "other whitespace",
+      "property": "response",
+      "input": "\n\r \t",
+      "expected": "Fine. Be that way!"
     },
     {
-      description => "non-question ending with whitespace".Str,
-      expected    => "Whatever.".Str,
-      input       => "This is a statement ending with whitespace      ".Str,
-      property    => "response".Str,
-    },
-  ],
-  exercise => "bob".Str,
-  version  => "1.0.0".Str,
-} }
+      "description": "non-question ending with whitespace",
+      "property": "response",
+      "input": "This is a statement ending with whitespace      ",
+      "expected": "Whatever."
+    }
+  ]
+}
+
+END
+}

--- a/exercises/clock/clock.t
+++ b/exercises/clock/clock.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Clock';
 my $version = v1;
@@ -55,492 +56,498 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
-    {
-      cases       => [
-        {
-          description => "on the hour".Str,
-          expected    => "08:00".Str,
-          hour        => 8.Int,
-          minute      => 0.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "past the hour".Str,
-          expected    => "11:09".Str,
-          hour        => 11.Int,
-          minute      => 9.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "midnight is zero hours".Str,
-          expected    => "00:00".Str,
-          hour        => 24.Int,
-          minute      => 0.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "hour rolls over".Str,
-          expected    => "01:00".Str,
-          hour        => 25.Int,
-          minute      => 0.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "hour rolls over continuously".Str,
-          expected    => "04:00".Str,
-          hour        => 100.Int,
-          minute      => 0.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "sixty minutes is next hour".Str,
-          expected    => "02:00".Str,
-          hour        => 1.Int,
-          minute      => 60.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "minutes roll over".Str,
-          expected    => "02:40".Str,
-          hour        => 0.Int,
-          minute      => 160.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "minutes roll over continuously".Str,
-          expected    => "04:43".Str,
-          hour        => 0.Int,
-          minute      => 1723.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "hour and minutes roll over".Str,
-          expected    => "03:40".Str,
-          hour        => 25.Int,
-          minute      => 160.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "hour and minutes roll over continuously".Str,
-          expected    => "11:01".Str,
-          hour        => 201.Int,
-          minute      => 3001.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "hour and minutes roll over to exactly midnight".Str,
-          expected    => "00:00".Str,
-          hour        => 72.Int,
-          minute      => 8640.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "negative hour".Str,
-          expected    => "23:15".Str,
-          hour        => -1.Int,
-          minute      => 15.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "negative hour rolls over".Str,
-          expected    => "23:00".Str,
-          hour        => -25.Int,
-          minute      => 0.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "negative hour rolls over continuously".Str,
-          expected    => "05:00".Str,
-          hour        => -91.Int,
-          minute      => 0.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "negative minutes".Str,
-          expected    => "00:20".Str,
-          hour        => 1.Int,
-          minute      => -40.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "negative minutes roll over".Str,
-          expected    => "22:20".Str,
-          hour        => 1.Int,
-          minute      => -160.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "negative minutes roll over continuously".Str,
-          expected    => "16:40".Str,
-          hour        => 1.Int,
-          minute      => -4820.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "negative hour and minutes both roll over".Str,
-          expected    => "20:20".Str,
-          hour        => -25.Int,
-          minute      => -160.Int,
-          property    => "create".Str,
-        },
-        {
-          description => "negative hour and minutes both roll over continuously".Str,
-          expected    => "22:10".Str,
-          hour        => -121.Int,
-          minute      => -5810.Int,
-          property    => "create".Str,
-        },
-      ],
-      description => "Create a new clock with an initial time".Str,
-    },
-    {
-      cases       => [
-        {
-          add         => 3.Int,
-          description => "add minutes".Str,
-          expected    => "10:03".Str,
-          hour        => 10.Int,
-          minute      => 0.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => 0.Int,
-          description => "add no minutes".Str,
-          expected    => "06:41".Str,
-          hour        => 6.Int,
-          minute      => 41.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => 40.Int,
-          description => "add to next hour".Str,
-          expected    => "01:25".Str,
-          hour        => 0.Int,
-          minute      => 45.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => 61.Int,
-          description => "add more than one hour".Str,
-          expected    => "11:01".Str,
-          hour        => 10.Int,
-          minute      => 0.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => 160.Int,
-          description => "add more than two hours with carry".Str,
-          expected    => "03:25".Str,
-          hour        => 0.Int,
-          minute      => 45.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => 2.Int,
-          description => "add across midnight".Str,
-          expected    => "00:01".Str,
-          hour        => 23.Int,
-          minute      => 59.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => 1500.Int,
-          description => "add more than one day (1500 min = 25 hrs)".Str,
-          expected    => "06:32".Str,
-          hour        => 5.Int,
-          minute      => 32.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => 3500.Int,
-          description => "add more than two days".Str,
-          expected    => "11:21".Str,
-          hour        => 1.Int,
-          minute      => 1.Int,
-          property    => "add".Str,
-        },
-      ],
-      description => "Add minutes".Str,
-    },
-    {
-      cases       => [
-        {
-          add         => -3.Int,
-          description => "subtract minutes".Str,
-          expected    => "10:00".Str,
-          hour        => 10.Int,
-          minute      => 3.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => -30.Int,
-          description => "subtract to previous hour".Str,
-          expected    => "09:33".Str,
-          hour        => 10.Int,
-          minute      => 3.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => -70.Int,
-          description => "subtract more than an hour".Str,
-          expected    => "08:53".Str,
-          hour        => 10.Int,
-          minute      => 3.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => -4.Int,
-          description => "subtract across midnight".Str,
-          expected    => "23:59".Str,
-          hour        => 0.Int,
-          minute      => 3.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => -160.Int,
-          description => "subtract more than two hours".Str,
-          expected    => "21:20".Str,
-          hour        => 0.Int,
-          minute      => 0.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => -160.Int,
-          description => "subtract more than two hours with borrow".Str,
-          expected    => "03:35".Str,
-          hour        => 6.Int,
-          minute      => 15.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => -1500.Int,
-          description => "subtract more than one day (1500 min = 25 hrs)".Str,
-          expected    => "04:32".Str,
-          hour        => 5.Int,
-          minute      => 32.Int,
-          property    => "add".Str,
-        },
-        {
-          add         => -3000.Int,
-          description => "subtract more than two days".Str,
-          expected    => "00:20".Str,
-          hour        => 2.Int,
-          minute      => 20.Int,
-          property    => "add".Str,
-        },
-      ],
-      description => "Subtract minutes".Str,
-    },
-    {
-      cases       => [
-        {
-          clock1      => {
-            hour   => 15.Int,
-            minute => 37.Int,
-          },
-          clock2      => {
-            hour   => 15.Int,
-            minute => 37.Int,
-          },
-          description => "clocks with same time".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 15.Int,
-            minute => 36.Int,
-          },
-          clock2      => {
-            hour   => 15.Int,
-            minute => 37.Int,
-          },
-          description => "clocks a minute apart".Str,
-          expected    => Bool::False.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 14.Int,
-            minute => 37.Int,
-          },
-          clock2      => {
-            hour   => 15.Int,
-            minute => 37.Int,
-          },
-          description => "clocks an hour apart".Str,
-          expected    => Bool::False.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 10.Int,
-            minute => 37.Int,
-          },
-          clock2      => {
-            hour   => 34.Int,
-            minute => 37.Int,
-          },
-          description => "clocks with hour overflow".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 3.Int,
-            minute => 11.Int,
-          },
-          clock2      => {
-            hour   => 99.Int,
-            minute => 11.Int,
-          },
-          description => "clocks with hour overflow by several days".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 22.Int,
-            minute => 40.Int,
-          },
-          clock2      => {
-            hour   => -2.Int,
-            minute => 40.Int,
-          },
-          description => "clocks with negative hour".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 17.Int,
-            minute => 3.Int,
-          },
-          clock2      => {
-            hour   => -31.Int,
-            minute => 3.Int,
-          },
-          description => "clocks with negative hour that wraps".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 13.Int,
-            minute => 49.Int,
-          },
-          clock2      => {
-            hour   => -83.Int,
-            minute => 49.Int,
-          },
-          description => "clocks with negative hour that wraps multiple times".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 0.Int,
-            minute => 1.Int,
-          },
-          clock2      => {
-            hour   => 0.Int,
-            minute => 1441.Int,
-          },
-          description => "clocks with minute overflow".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 2.Int,
-            minute => 2.Int,
-          },
-          clock2      => {
-            hour   => 2.Int,
-            minute => 4322.Int,
-          },
-          description => "clocks with minute overflow by several days".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 2.Int,
-            minute => 40.Int,
-          },
-          clock2      => {
-            hour   => 3.Int,
-            minute => -20.Int,
-          },
-          description => "clocks with negative minute".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 4.Int,
-            minute => 10.Int,
-          },
-          clock2      => {
-            hour   => 5.Int,
-            minute => -1490.Int,
-          },
-          description => "clocks with negative minute that wraps".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 6.Int,
-            minute => 15.Int,
-          },
-          clock2      => {
-            hour   => 6.Int,
-            minute => -4305.Int,
-          },
-          description => "clocks with negative minute that wraps multiple times".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 7.Int,
-            minute => 32.Int,
-          },
-          clock2      => {
-            hour   => -12.Int,
-            minute => -268.Int,
-          },
-          description => "clocks with negative hours and minutes".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-        {
-          clock1      => {
-            hour   => 18.Int,
-            minute => 7.Int,
-          },
-          clock2      => {
-            hour   => -54.Int,
-            minute => -11513.Int,
-          },
-          description => "clocks with negative hours and minutes that wrap".Str,
-          expected    => Bool::True.Bool,
-          property    => "equal".Str,
-        },
-      ],
-      description => "Compare two clocks for equality".Str,
-    },
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "clock",
+  "version": "1.0.1",
+  "comments": [
+    "Most languages require constructing a clock with initial values,",
+    "adding a positive or negative number of minutes, and testing equality",
+    "in some language-native way.  Some languages require separate add and",
+    "subtract functions.  Negative and out of range values are generally",
+    "expected to wrap around rather than represent errors."
   ],
-  comments => [
-    "Most languages require constructing a clock with initial values,".Str,
-    "adding a positive or negative number of minutes, and testing equality".Str,
-    "in some language-native way.  Some languages require separate add and".Str,
-    "subtract functions.  Negative and out of range values are generally".Str,
-    "expected to wrap around rather than represent errors.".Str,
-  ],
-  exercise => "clock".Str,
-  version  => "1.0.1".Str,
-} }
+  "cases": [
+    {
+      "description": "Create a new clock with an initial time",
+      "cases": [
+        {
+          "description": "on the hour",
+          "property": "create",
+          "hour": 8,
+          "minute": 0,
+          "expected": "08:00"
+        },
+        {
+          "description": "past the hour",
+          "property": "create",
+          "hour": 11,
+          "minute": 9,
+          "expected": "11:09"
+        },
+        {
+          "description": "midnight is zero hours",
+          "property": "create",
+          "hour": 24,
+          "minute": 0,
+          "expected": "00:00"
+        },
+        {
+          "description": "hour rolls over",
+          "property": "create",
+          "hour": 25,
+          "minute": 0,
+          "expected": "01:00"
+        },
+        {
+          "description": "hour rolls over continuously",
+          "property": "create",
+          "hour": 100,
+          "minute": 0,
+          "expected": "04:00"
+        },
+        {
+          "description": "sixty minutes is next hour",
+          "property": "create",
+          "hour": 1,
+          "minute": 60,
+          "expected": "02:00"
+        },
+        {
+          "description": "minutes roll over",
+          "property": "create",
+          "hour": 0,
+          "minute": 160,
+          "expected": "02:40"
+        },
+        {
+          "description": "minutes roll over continuously",
+          "property": "create",
+          "hour": 0,
+          "minute": 1723,
+          "expected": "04:43"
+        },
+        {
+          "description": "hour and minutes roll over",
+          "property": "create",
+          "hour": 25,
+          "minute": 160,
+          "expected": "03:40"
+        },
+        {
+          "description": "hour and minutes roll over continuously",
+          "property": "create",
+          "hour": 201,
+          "minute": 3001,
+          "expected": "11:01"
+        },
+        {
+          "description": "hour and minutes roll over to exactly midnight",
+          "property": "create",
+          "hour": 72,
+          "minute": 8640,
+          "expected": "00:00"
+        },
+        {
+          "description": "negative hour",
+          "property": "create",
+          "hour": -1,
+          "minute": 15,
+          "expected": "23:15"
+        },
+        {
+          "description": "negative hour rolls over",
+          "property": "create",
+          "hour": -25,
+          "minute": 0,
+          "expected": "23:00"
+        },
+        {
+          "description": "negative hour rolls over continuously",
+          "property": "create",
+          "hour": -91,
+          "minute": 0,
+          "expected": "05:00"
+        },
+        {
+          "description": "negative minutes",
+          "property": "create",
+          "hour": 1,
+          "minute": -40,
+          "expected": "00:20"
+        },
+        {
+          "description": "negative minutes roll over",
+          "property": "create",
+          "hour": 1,
+          "minute": -160,
+          "expected": "22:20"
+        },
+        {
+          "description": "negative minutes roll over continuously",
+          "property": "create",
+          "hour": 1,
+          "minute": -4820,
+          "expected": "16:40"
+        },
+        {
+          "description": "negative hour and minutes both roll over",
+          "property": "create",
+          "hour": -25,
+          "minute": -160,
+          "expected": "20:20"
+        },
+        {
+          "description": "negative hour and minutes both roll over continuously",
+          "property": "create",
+          "hour": -121,
+          "minute": -5810,
+          "expected": "22:10"
+        }
+      ]
+    },
+    {
+      "description": "Add minutes",
+      "cases": [
+        {
+          "description": "add minutes",
+          "property": "add",
+          "hour": 10,
+          "minute": 0,
+          "add": 3,
+          "expected": "10:03"
+        },
+        {
+          "description": "add no minutes",
+          "property": "add",
+          "hour": 6,
+          "minute": 41,
+          "add": 0,
+          "expected": "06:41"
+        },
+        {
+          "description": "add to next hour",
+          "property": "add",
+          "hour": 0,
+          "minute": 45,
+          "add": 40,
+          "expected": "01:25"
+        },
+        {
+          "description": "add more than one hour",
+          "property": "add",
+          "hour": 10,
+          "minute": 0,
+          "add": 61,
+          "expected": "11:01"
+        },
+        {
+          "description": "add more than two hours with carry",
+          "property": "add",
+          "hour": 0,
+          "minute": 45,
+          "add": 160,
+          "expected": "03:25"
+        },
+        {
+          "description": "add across midnight",
+          "property": "add",
+          "hour": 23,
+          "minute": 59,
+          "add": 2,
+          "expected": "00:01"
+        },
+        {
+          "description": "add more than one day (1500 min = 25 hrs)",
+          "property": "add",
+          "hour": 5,
+          "minute": 32,
+          "add": 1500,
+          "expected": "06:32"
+        },
+        {
+          "description": "add more than two days",
+          "property": "add",
+          "hour": 1,
+          "minute": 1,
+          "add": 3500,
+          "expected": "11:21"
+        }
+      ]
+    },
+    {
+      "description": "Subtract minutes",
+      "cases": [
+        {
+          "description": "subtract minutes",
+          "property": "add",
+          "hour": 10,
+          "minute": 3,
+          "add": -3,
+          "expected": "10:00"
+        },
+        {
+          "description": "subtract to previous hour",
+          "property": "add",
+          "hour": 10,
+          "minute": 3,
+          "add": -30,
+          "expected": "09:33"
+        },
+        {
+          "description": "subtract more than an hour",
+          "property": "add",
+          "hour": 10,
+          "minute": 3,
+          "add": -70,
+          "expected": "08:53"
+        },
+        {
+          "description": "subtract across midnight",
+          "property": "add",
+          "hour": 0,
+          "minute": 3,
+          "add": -4,
+          "expected": "23:59"
+        },
+        {
+          "description": "subtract more than two hours",
+          "property": "add",
+          "hour": 0,
+          "minute": 0,
+          "add": -160,
+          "expected": "21:20"
+        },
+        {
+          "description": "subtract more than two hours with borrow",
+          "property": "add",
+          "hour": 6,
+          "minute": 15,
+          "add": -160,
+          "expected": "03:35"
+        },
+        {
+          "description": "subtract more than one day (1500 min = 25 hrs)",
+          "property": "add",
+          "hour": 5,
+          "minute": 32,
+          "add": -1500,
+          "expected": "04:32"
+        },
+        {
+          "description": "subtract more than two days",
+          "property": "add",
+          "hour": 2,
+          "minute": 20,
+          "add": -3000,
+          "expected": "00:20"
+        }
+      ]
+    },
+    {
+      "description": "Compare two clocks for equality",
+      "cases": [
+        {
+          "description": "clocks with same time",
+          "property": "equal",
+          "clock1": {
+            "hour": 15,
+            "minute": 37
+          },
+          "clock2": {
+            "hour": 15,
+            "minute": 37
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks a minute apart",
+          "property": "equal",
+          "clock1": {
+            "hour": 15,
+            "minute": 36
+          },
+          "clock2": {
+            "hour": 15,
+            "minute": 37
+          },
+          "expected": false
+        },
+        {
+          "description": "clocks an hour apart",
+          "property": "equal",
+          "clock1": {
+            "hour": 14,
+            "minute": 37
+          },
+          "clock2": {
+            "hour": 15,
+            "minute": 37
+          },
+          "expected": false
+        },
+        {
+          "description": "clocks with hour overflow",
+          "property": "equal",
+          "clock1": {
+            "hour": 10,
+            "minute": 37
+          },
+          "clock2": {
+            "hour": 34,
+            "minute": 37
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with hour overflow by several days",
+          "property": "equal",
+          "clock1": {
+            "hour": 3,
+            "minute": 11
+          },
+          "clock2": {
+            "hour": 99,
+            "minute": 11
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with negative hour",
+          "property": "equal",
+          "clock1": {
+            "hour": 22,
+            "minute": 40
+          },
+          "clock2": {
+            "hour": -2,
+            "minute": 40
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with negative hour that wraps",
+          "property": "equal",
+          "clock1": {
+            "hour": 17,
+            "minute": 3
+          },
+          "clock2": {
+            "hour": -31,
+            "minute": 3
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with negative hour that wraps multiple times",
+          "property": "equal",
+          "clock1": {
+            "hour": 13,
+            "minute": 49
+          },
+          "clock2": {
+            "hour": -83,
+            "minute": 49
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with minute overflow",
+          "property": "equal",
+          "clock1": {
+            "hour": 0,
+            "minute": 1
+          },
+          "clock2": {
+            "hour": 0,
+            "minute": 1441
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with minute overflow by several days",
+          "property": "equal",
+          "clock1": {
+            "hour": 2,
+            "minute": 2
+          },
+          "clock2": {
+            "hour": 2,
+            "minute": 4322
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with negative minute",
+          "property": "equal",
+          "clock1": {
+            "hour": 2,
+            "minute": 40
+          },
+          "clock2": {
+            "hour": 3,
+            "minute": -20
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with negative minute that wraps",
+          "property": "equal",
+          "clock1": {
+            "hour": 4,
+            "minute": 10
+          },
+          "clock2": {
+            "hour": 5,
+            "minute": -1490
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with negative minute that wraps multiple times",
+          "property": "equal",
+          "clock1": {
+            "hour": 6,
+            "minute": 15
+          },
+          "clock2": {
+            "hour": 6,
+            "minute": -4305
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with negative hours and minutes",
+          "property": "equal",
+          "clock1": {
+            "hour": 7,
+            "minute": 32
+          },
+          "clock2": {
+            "hour": -12,
+            "minute": -268
+          },
+          "expected": true
+        },
+        {
+          "description": "clocks with negative hours and minutes that wrap",
+          "property": "equal",
+          "clock1": {
+            "hour": 18,
+            "minute": 7
+          },
+          "clock2": {
+            "hour": -54,
+            "minute": -11513
+          },
+          "expected": true
+        }
+      ]
+    }
+  ]
+}
+
+END
+}

--- a/exercises/flatten-array/flatten-array.t
+++ b/exercises/flatten-array/flatten-array.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'FlattenArray';
 my $version = v1;
@@ -31,182 +32,51 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "flatten-array",
+  "version": "1.1.0",
+  "cases": [
     {
-      description => "no nesting".Str,
-      expected    => [
-        0.Int,
-        1.Int,
-        2.Int,
-      ],
-      input       => [
-        0.Int,
-        1.Int,
-        2.Int,
-      ],
-      property    => "flatten".Str,
+      "description": "no nesting",
+      "property": "flatten",
+      "input": [0, 1, 2],
+      "expected": [0, 1, 2]
     },
     {
-      description => "flattens array with just integers present".Str,
-      expected    => [
-        1.Int,
-        2.Int,
-        3.Int,
-        4.Int,
-        5.Int,
-        6.Int,
-        7.Int,
-        8.Int,
-      ],
-      input       => [
-        1.Int,
-        [
-          2.Int,
-          3.Int,
-          4.Int,
-          5.Int,
-          6.Int,
-          7.Int,
-        ],
-        8.Int,
-      ],
-      property    => "flatten".Str,
+      "description": "flattens array with just integers present",
+      "property": "flatten",
+      "input": [1, [2, 3, 4, 5, 6, 7], 8],
+      "expected": [1, 2, 3, 4, 5, 6, 7, 8]
     },
     {
-      description => "5 level nesting".Str,
-      expected    => [
-        0.Int,
-        2.Int,
-        2.Int,
-        3.Int,
-        8.Int,
-        100.Int,
-        4.Int,
-        50.Int,
-        -2.Int,
-      ],
-      input       => [
-        0.Int,
-        2.Int,
-        [
-          [
-            2.Int,
-            3.Int,
-          ],
-          8.Int,
-          100.Int,
-          4.Int,
-          [
-            [
-              [
-                50.Int,
-              ],
-            ],
-          ],
-        ],
-        -2.Int,
-      ],
-      property    => "flatten".Str,
+      "description": "5 level nesting",
+      "property": "flatten",
+      "input": [0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2],
+      "expected": [0, 2, 2, 3, 8, 100, 4, 50, -2]
     },
     {
-      description => "6 level nesting".Str,
-      expected    => [
-        1.Int,
-        2.Int,
-        3.Int,
-        4.Int,
-        5.Int,
-        6.Int,
-        7.Int,
-        8.Int,
-      ],
-      input       => [
-        1.Int,
-        [
-          2.Int,
-          [
-            [
-              3.Int,
-            ],
-          ],
-          [
-            4.Int,
-            [
-              [
-                5.Int,
-              ],
-            ],
-          ],
-          6.Int,
-          7.Int,
-        ],
-        8.Int,
-      ],
-      property    => "flatten".Str,
+      "description": "6 level nesting",
+      "property": "flatten",
+      "input": [1, [2, [[3]], [4, [[5]]], 6, 7], 8],
+      "expected": [1, 2, 3, 4, 5, 6, 7, 8]
     },
     {
-      description => "6 level nest list with null values".Str,
-      expected    => [
-        0.Int,
-        2.Int,
-        2.Int,
-        3.Int,
-        8.Int,
-        100.Int,
-        -2.Int,
-      ],
-      input       => [
-        0.Int,
-        2.Int,
-        [
-          [
-            2.Int,
-            3.Int,
-          ],
-          8.Int,
-          [
-            [
-              100.Int,
-            ],
-          ],
-          (Any),
-          [
-            [
-              (Any),
-            ],
-          ],
-        ],
-        -2.Int,
-      ],
-      property    => "flatten".Str,
+      "description": "6 level nest list with null values",
+      "property": "flatten",
+      "input": [0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2],
+      "expected": [0, 2, 2, 3, 8, 100, -2]
     },
     {
-      description => "all values in nested list are null".Str,
-      expected    => [ ],
-      input       => [
-        (Any),
-        [
-          [
-            [
-              (Any),
-            ],
-          ],
-        ],
-        (Any),
-        (Any),
-        [
-          [
-            (Any),
-            (Any),
-          ],
-          (Any),
-        ],
-        (Any),
-      ],
-      property    => "flatten".Str,
-    },
-  ],
-  exercise => "flatten-array".Str,
-  version  => "1.1.0".Str,
-} }
+      "description": "all values in nested list are null",
+      "property": "flatten",
+      "input": [null, [[[null]]], null, null, [[null, null], null], null],
+      "expected": []
+    }
+  ]
+}
+
+END
+}

--- a/exercises/grains/grains.t
+++ b/exercises/grains/grains.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Grains';
 my $version = v1;
@@ -38,84 +39,90 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "grains",
+  "version": "1.0.0",
+  "comments": [
+    "The final tests of square test error conditions",
+    "The expection for these tests is -1, indicating an error",
+    "In these cases you should expect an error as is idiomatic for your language"
+  ],
+  "cases": [
     {
-      cases       => [
+      "description": "returns the number of grains on the square",
+      "cases": [
         {
-          description => "1".Str,
-          expected    => 1.Int,
-          input       => 1.Int,
-          property    => "square".Str,
+          "description": "1",
+          "property": "square",
+          "input": 1,
+          "expected": 1
         },
         {
-          description => "2".Str,
-          expected    => 2.Int,
-          input       => 2.Int,
-          property    => "square".Str,
+          "description": "2",
+          "property": "square",
+          "input": 2,
+          "expected": 2
         },
         {
-          description => "3".Str,
-          expected    => 4.Int,
-          input       => 3.Int,
-          property    => "square".Str,
+          "description": "3",
+          "property": "square",
+          "input": 3,
+          "expected": 4
         },
         {
-          description => "4".Str,
-          expected    => 8.Int,
-          input       => 4.Int,
-          property    => "square".Str,
+          "description": "4",
+          "property": "square",
+          "input": 4,
+          "expected": 8
         },
         {
-          description => "16".Str,
-          expected    => 32768.Int,
-          input       => 16.Int,
-          property    => "square".Str,
+          "description": "16",
+          "property": "square",
+          "input": 16,
+          "expected": 32768
         },
         {
-          description => "32".Str,
-          expected    => 2147483648.Int,
-          input       => 32.Int,
-          property    => "square".Str,
+          "description": "32",
+          "property": "square",
+          "input": 32,
+          "expected": 2147483648
         },
         {
-          description => "64".Str,
-          expected    => 9223372036854775808.Int,
-          input       => 64.Int,
-          property    => "square".Str,
+          "description": "64",
+          "property": "square",
+          "input": 64,
+          "expected": 9223372036854775808
         },
         {
-          description => "square 0 raises an exception".Str,
-          expected    => -1.Int,
-          input       => 0.Int,
-          property    => "square".Str,
+          "description": "square 0 raises an exception",
+          "property": "square",
+          "input": 0,
+          "expected": -1
         },
         {
-          description => "negative square raises an exception".Str,
-          expected    => -1.Int,
-          input       => -1.Int,
-          property    => "square".Str,
+          "description": "negative square raises an exception",
+          "property": "square",
+          "input": -1,
+          "expected": -1
         },
         {
-          description => "square greater than 64 raises an exception".Str,
-          expected    => -1.Int,
-          input       => 65.Int,
-          property    => "square".Str,
-        },
-      ],
-      description => "returns the number of grains on the square".Str,
+          "description": "square greater than 64 raises an exception",
+          "property": "square",
+          "input": 65,
+          "expected": -1
+        }
+      ]
     },
     {
-      description => "returns the total number of grains on the board".Str,
-      expected    => 18446744073709551615.Int,
-      property    => "total".Str,
-    },
-  ],
-  comments => [
-    "The final tests of square test error conditions".Str,
-    "The expection for these tests is -1, indicating an error".Str,
-    "In these cases you should expect an error as is idiomatic for your language".Str,
-  ],
-  exercise => "grains".Str,
-  version  => "1.0.0".Str,
-} }
+      "description": "returns the total number of grains on the board",
+      "property": "total",
+      "expected": 18446744073709551615
+    }
+  ]
+}
+
+END
+}

--- a/exercises/hello-world/hello-world.t
+++ b/exercises/hello-world/hello-world.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname; #`[Look for the module inside the same directory as this test file.]
+use JSON::Fast;
 
 my $exercise = 'HelloWorld'; #`[The name of this exercise.]
 my $version = v2; #`[The version we will be matching against the exercise.]
@@ -40,14 +41,20 @@ done-testing; #`[There are no more tests after this :)]
 
 #`['INIT' is a phaser, it makes sure that the test data is available before everything else
 starts running (otherwise we'd have to shove the test data into the middle of the file!)]
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "hello-world",
+  "version": "1.0.0",
+  "cases": [
     {
-      description => "Say Hi!".Str,
-      expected    => "Hello, World!".Str,
-      property    => "hello".Str,
-    },
-  ],
-  exercise => "hello-world".Str,
-  version  => "1.0.0".Str,
-} }
+      "description": "Say Hi!",
+      "property": "hello",
+      "expected": "Hello, World!"
+    }
+  ]
+}
+
+END
+}

--- a/exercises/leap/leap.t
+++ b/exercises/leap/leap.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Leap';
 my $version = v1;
@@ -31,33 +32,39 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "leap",
+  "version": "1.0.0",
+  "cases": [
     {
-      description => "year not divisible by 4: common year".Str,
-      expected    => Bool::False.Bool,
-      input       => 2015.Int,
-      property    => "leapYear".Str,
+      "description": "year not divisible by 4: common year",
+      "property": "leapYear",
+      "input": 2015,
+      "expected": false
     },
     {
-      description => "year divisible by 4, not divisible by 100: leap year".Str,
-      expected    => Bool::True.Bool,
-      input       => 2016.Int,
-      property    => "leapYear".Str,
+      "description": "year divisible by 4, not divisible by 100: leap year",
+      "property": "leapYear",
+      "input": 2016,
+      "expected": true
     },
     {
-      description => "year divisible by 100, not divisible by 400: common year".Str,
-      expected    => Bool::False.Bool,
-      input       => 2100.Int,
-      property    => "leapYear".Str,
+      "description": "year divisible by 100, not divisible by 400: common year",
+      "property": "leapYear",
+      "input": 2100,
+      "expected": false
     },
     {
-      description => "year divisible by 400: leap year".Str,
-      expected    => Bool::True.Bool,
-      input       => 2000.Int,
-      property    => "leapYear".Str,
-    },
-  ],
-  exercise => "leap".Str,
-  version  => "1.0.0".Str,
-} }
+      "description": "year divisible by 400: leap year",
+      "property": "leapYear",
+      "input": 2000,
+      "expected": true
+    }
+  ]
+}
+
+END
+}

--- a/exercises/luhn/luhn.t
+++ b/exercises/luhn/luhn.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Luhn';
 my $version = v1;
@@ -31,87 +32,93 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "luhn",
+  "version": "1.0.0",
+  "cases": [
     {
-      description => "single digit strings can not be valid".Str,
-      expected    => Bool::False.Bool,
-      input       => "1".Str,
-      property    => "valid".Str,
+      "description": "single digit strings can not be valid",
+      "property": "valid",
+      "input": "1",
+      "expected": false
     },
     {
-      description => "A single zero is invalid".Str,
-      expected    => Bool::False.Bool,
-      input       => "0".Str,
-      property    => "valid".Str,
+      "description": "A single zero is invalid",
+      "property": "valid",
+      "input": "0",
+      "expected": false
     },
     {
-      description => "a simple valid SIN that remains valid if reversed".Str,
-      expected    => Bool::True.Bool,
-      input       => "059".Str,
-      property    => "valid".Str,
+      "description": "a simple valid SIN that remains valid if reversed",
+      "property": "valid",
+      "input": "059",
+      "expected": true
     },
     {
-      description => "a simple valid SIN that becomes invalid if reversed".Str,
-      expected    => Bool::True.Bool,
-      input       => "59".Str,
-      property    => "valid".Str,
+      "description": "a simple valid SIN that becomes invalid if reversed",
+      "property": "valid",
+      "input": "59",
+      "expected": true
     },
     {
-      description => "a valid Canadian SIN".Str,
-      expected    => Bool::True.Bool,
-      input       => "055 444 285".Str,
-      property    => "valid".Str,
+      "description": "a valid Canadian SIN",
+      "property": "valid",
+      "input": "055 444 285",
+      "expected": true
     },
     {
-      description => "invalid Canadian SIN".Str,
-      expected    => Bool::False.Bool,
-      input       => "055 444 286".Str,
-      property    => "valid".Str,
+      "description": "invalid Canadian SIN",
+      "property": "valid",
+      "input": "055 444 286",
+      "expected": false
     },
     {
-      description => "invalid credit card".Str,
-      expected    => Bool::False.Bool,
-      input       => "8273 1232 7352 0569".Str,
-      property    => "valid".Str,
+      "description": "invalid credit card",
+      "property": "valid",
+      "input": "8273 1232 7352 0569",
+      "expected": false
     },
     {
-      description => "valid strings with a non-digit included become invalid".Str,
-      expected    => Bool::False.Bool,
-      input       => "055a 444 285".Str,
-      property    => "valid".Str,
+      "description": "valid strings with a non-digit included become invalid",
+      "property": "valid",
+      "input": "055a 444 285",
+      "expected": false
     },
     {
-      description => "valid strings with punctuation included become invalid".Str,
-      expected    => Bool::False.Bool,
-      input       => "055-444-285".Str,
-      property    => "valid".Str,
+      "description": "valid strings with punctuation included become invalid",
+      "property": "valid",
+      "input": "055-444-285",
+      "expected": false
     },
     {
-      description => "valid strings with symbols included become invalid".Str,
-      expected    => Bool::False.Bool,
-      input       => "055£ 444\$ 285".Str,
-      property    => "valid".Str,
+      "description": "valid strings with symbols included become invalid",
+      "property": "valid",
+      "input": "055£ 444$ 285",
+      "expected": false
     },
     {
-      description => "single zero with space is invalid".Str,
-      expected    => Bool::False.Bool,
-      input       => " 0".Str,
-      property    => "valid".Str,
+      "description": "single zero with space is invalid",
+      "property": "valid",
+      "input": " 0",
+      "expected": false
     },
     {
-      description => "more than a single zero is valid".Str,
-      expected    => Bool::True.Bool,
-      input       => "0000 0".Str,
-      property    => "valid".Str,
+      "description": "more than a single zero is valid",
+      "property": "valid",
+      "input": "0000 0",
+      "expected": true
     },
     {
-      description => "input digit 9 is correctly converted to output digit 9".Str,
-      expected    => Bool::True.Bool,
-      input       => "091".Str,
-      property    => "valid".Str,
-    },
-  ],
-  exercise => "luhn".Str,
-  version  => "1.0.0".Str,
-} }
+      "description": "input digit 9 is correctly converted to output digit 9",
+      "property": "valid",
+      "input": "091",
+      "expected": true
+    }
+  ]
+}
+
+END
+}

--- a/exercises/phone-number/phone-number.t
+++ b/exercises/phone-number/phone-number.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Phone';
 my $version = v3;
@@ -37,91 +38,97 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "phone-number",
+  "version": "1.2.0",
+  "cases": [
     {
-      cases       => [
-        {
-          description => "cleans the number".Str,
-          expected    => "2234567890".Str,
-          phrase      => "(223) 456-7890".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "cleans numbers with dots".Str,
-          expected    => "2234567890".Str,
-          phrase      => "223.456.7890".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "cleans numbers with multiple spaces".Str,
-          expected    => "2234567890".Str,
-          phrase      => "223 456   7890   ".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "invalid when 9 digits".Str,
-          expected    => (Any),
-          phrase      => "123456789".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "invalid when 11 digits does not start with a 1".Str,
-          expected    => (Any),
-          phrase      => "22234567890".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "valid when 11 digits and starting with 1".Str,
-          expected    => "2234567890".Str,
-          phrase      => "12234567890".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "valid when 11 digits and starting with 1 even with punctuation".Str,
-          expected    => "2234567890".Str,
-          phrase      => "+1 (223) 456-7890".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "invalid when more than 11 digits".Str,
-          expected    => (Any),
-          phrase      => "321234567890".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "invalid with letters".Str,
-          expected    => (Any),
-          phrase      => "123-abc-7890".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "invalid with punctuations".Str,
-          expected    => (Any),
-          phrase      => "123-\@:!-7890".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "invalid if area code does not start with 2-9".Str,
-          expected    => (Any),
-          phrase      => "(123) 456-7890".Str,
-          property    => "clean".Str,
-        },
-        {
-          description => "invalid if exchange code does not start with 2-9".Str,
-          expected    => (Any),
-          phrase      => "(223) 056-7890".Str,
-          property    => "clean".Str,
-        },
+      "description": "Cleanup user-entered phone numbers",
+      "comments": [
+        " Returns the cleaned phone number if given number is valid, "
+      , " else returns nil. Note that number is not formatted,       "
+      , " just a 10-digit number is returned.                        "
       ],
-      comments    => [
-        " Returns the cleaned phone number if given number is valid, ".Str,
-        " else returns nil. Note that number is not formatted,       ".Str,
-        " just a 10-digit number is returned.                        ".Str,
-      ],
-      description => "Cleanup user-entered phone numbers".Str,
-    },
-  ],
-  exercise => "phone-number".Str,
-  version  => "1.2.0".Str,
-} }
+      "cases": [
+        {
+          "description": "cleans the number",
+          "property": "clean",
+          "phrase": "(223) 456-7890",
+          "expected": "2234567890"
+        },
+        {
+          "description": "cleans numbers with dots",
+          "property": "clean",
+          "phrase": "223.456.7890",
+          "expected": "2234567890"
+        },
+        {
+          "description": "cleans numbers with multiple spaces",
+          "property": "clean",
+          "phrase": "223 456   7890   ",
+          "expected": "2234567890"
+        },
+        {
+          "description": "invalid when 9 digits",
+          "property": "clean",
+          "phrase": "123456789",
+          "expected": null
+        },
+        {
+          "description": "invalid when 11 digits does not start with a 1",
+          "property": "clean",
+          "phrase": "22234567890",
+          "expected": null
+        },
+        {
+          "description": "valid when 11 digits and starting with 1",
+          "property": "clean",
+          "phrase": "12234567890",
+          "expected": "2234567890"
+        },
+        {
+          "description": "valid when 11 digits and starting with 1 even with punctuation",
+          "property": "clean",
+          "phrase": "+1 (223) 456-7890",
+          "expected": "2234567890"
+        },
+        {
+          "description": "invalid when more than 11 digits",
+          "property": "clean",
+          "phrase": "321234567890",
+          "expected": null
+        },
+        {
+          "description": "invalid with letters",
+          "property": "clean",
+          "phrase": "123-abc-7890",
+          "expected": null
+        },
+        {
+          "description": "invalid with punctuations",
+          "property": "clean",
+          "phrase": "123-@:!-7890",
+          "expected": null
+        },
+        {
+          "description": "invalid if area code does not start with 2-9",
+          "property": "clean",
+          "phrase": "(123) 456-7890",
+          "expected": null
+        },
+        {
+          "description": "invalid if exchange code does not start with 2-9",
+          "property": "clean",
+          "phrase": "(223) 056-7890",
+          "expected": null
+        }
+      ]
+    }
+  ]
+}
+
+END
+}

--- a/exercises/raindrops/raindrops.t
+++ b/exercises/raindrops/raindrops.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Raindrops';
 my $version = v1;
@@ -37,117 +38,123 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "raindrops",
+  "version": "1.0.0",
+  "cases": [
     {
-      description => "the sound for 1 is 1".Str,
-      expected    => "1".Str,
-      number      => 1.Int,
-      property    => "convert".Str,
+      "description": "the sound for 1 is 1",
+      "property": "convert",
+      "number": 1,
+      "expected": "1"
     },
     {
-      description => "the sound for 3 is Pling".Str,
-      expected    => "Pling".Str,
-      number      => 3.Int,
-      property    => "convert".Str,
+      "description": "the sound for 3 is Pling",
+      "property": "convert",
+      "number": 3,
+      "expected": "Pling"
     },
     {
-      description => "the sound for 5 is Plang".Str,
-      expected    => "Plang".Str,
-      number      => 5.Int,
-      property    => "convert".Str,
+      "description": "the sound for 5 is Plang",
+      "property": "convert",
+      "number": 5,
+      "expected": "Plang"
     },
     {
-      description => "the sound for 7 is Plong".Str,
-      expected    => "Plong".Str,
-      number      => 7.Int,
-      property    => "convert".Str,
+      "description": "the sound for 7 is Plong",
+      "property": "convert",
+      "number": 7,
+      "expected": "Plong"
     },
     {
-      description => "the sound for 6 is Pling as it has a factor 3".Str,
-      expected    => "Pling".Str,
-      number      => 6.Int,
-      property    => "convert".Str,
+      "description": "the sound for 6 is Pling as it has a factor 3",
+      "property": "convert",
+      "number": 6,
+      "expected": "Pling"
     },
     {
-      description => "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base".Str,
-      expected    => "8".Str,
-      number      => 8.Int,
-      property    => "convert".Str,
+      "description": "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base",
+      "property": "convert",
+      "number": 8,
+      "expected": "8"
     },
     {
-      description => "the sound for 9 is Pling as it has a factor 3".Str,
-      expected    => "Pling".Str,
-      number      => 9.Int,
-      property    => "convert".Str,
+      "description": "the sound for 9 is Pling as it has a factor 3",
+      "property": "convert",
+      "number": 9,
+      "expected": "Pling"
     },
     {
-      description => "the sound for 10 is Plang as it has a factor 5".Str,
-      expected    => "Plang".Str,
-      number      => 10.Int,
-      property    => "convert".Str,
+      "description": "the sound for 10 is Plang as it has a factor 5",
+      "property": "convert",
+      "number": 10,
+      "expected": "Plang"
     },
     {
-      description => "the sound for 14 is Plong as it has a factor of 7".Str,
-      expected    => "Plong".Str,
-      number      => 14.Int,
-      property    => "convert".Str,
+      "description": "the sound for 14 is Plong as it has a factor of 7",
+      "property": "convert",
+      "number": 14,
+      "expected": "Plong"
     },
     {
-      description => "the sound for 15 is PlingPlang as it has factors 3 and 5".Str,
-      expected    => "PlingPlang".Str,
-      number      => 15.Int,
-      property    => "convert".Str,
+      "description": "the sound for 15 is PlingPlang as it has factors 3 and 5",
+      "property": "convert",
+      "number": 15,
+      "expected": "PlingPlang"
     },
     {
-      description => "the sound for 21 is PlingPlong as it has factors 3 and 7".Str,
-      expected    => "PlingPlong".Str,
-      number      => 21.Int,
-      property    => "convert".Str,
+      "description": "the sound for 21 is PlingPlong as it has factors 3 and 7",
+      "property": "convert",
+      "number": 21,
+      "expected": "PlingPlong"
     },
     {
-      description => "the sound for 25 is Plang as it has a factor 5".Str,
-      expected    => "Plang".Str,
-      number      => 25.Int,
-      property    => "convert".Str,
+      "description": "the sound for 25 is Plang as it has a factor 5",
+      "property": "convert",
+      "number": 25,
+      "expected": "Plang"
     },
     {
-      description => "the sound for 27 is Pling as it has a factor 3".Str,
-      expected    => "Pling".Str,
-      number      => 27.Int,
-      property    => "convert".Str,
+      "description": "the sound for 27 is Pling as it has a factor 3",
+      "property": "convert",
+      "number": 27,
+      "expected": "Pling"
     },
     {
-      description => "the sound for 35 is PlangPlong as it has factors 5 and 7".Str,
-      expected    => "PlangPlong".Str,
-      number      => 35.Int,
-      property    => "convert".Str,
+      "description": "the sound for 35 is PlangPlong as it has factors 5 and 7",
+      "property": "convert",
+      "number": 35,
+      "expected": "PlangPlong"
     },
     {
-      description => "the sound for 49 is Plong as it has a factor 7".Str,
-      expected    => "Plong".Str,
-      number      => 49.Int,
-      property    => "convert".Str,
+      "description": "the sound for 49 is Plong as it has a factor 7",
+      "property": "convert",
+      "number": 49,
+      "expected": "Plong"
     },
     {
-      description => "the sound for 52 is 52".Str,
-      expected    => "52".Str,
-      number      => 52.Int,
-      property    => "convert".Str,
+      "description": "the sound for 52 is 52",
+      "property": "convert",
+      "number": 52,
+      "expected": "52"
     },
     {
-      description => "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7".Str,
-      expected    => "PlingPlangPlong".Str,
-      number      => 105.Int,
-      property    => "convert".Str,
+      "description": "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7",
+      "property": "convert",
+      "number": 105,
+      "expected": "PlingPlangPlong"
     },
     {
-      description => "the sound for 3125 is Plang as it has a factor 5".Str,
-      expected    => "Plang".Str,
-      number      => 3125.Int,
-      property    => "convert".Str,
-    },
-  ],
-  exercise => "raindrops".Str,
-  version  => "1.0.0".Str,
-} }
+      "description": "the sound for 3125 is Plang as it has a factor 5",
+      "property": "convert",
+      "number": 3125,
+      "expected": "Plang"
+    }
+  ]
+}
+
+END
+}

--- a/exercises/rna-transcription/rna-transcription.t
+++ b/exercises/rna-transcription/rna-transcription.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'RNA';
 my $version = v1;
@@ -37,69 +38,75 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
-    {
-      description => "RNA complement of cytosine is guanine".Str,
-      dna         => "C".Str,
-      expected    => "G".Str,
-      property    => "toRna".Str,
-    },
-    {
-      description => "RNA complement of guanine is cytosine".Str,
-      dna         => "G".Str,
-      expected    => "C".Str,
-      property    => "toRna".Str,
-    },
-    {
-      description => "RNA complement of thymine is adenine".Str,
-      dna         => "T".Str,
-      expected    => "A".Str,
-      property    => "toRna".Str,
-    },
-    {
-      description => "RNA complement of adenine is uracil".Str,
-      dna         => "A".Str,
-      expected    => "U".Str,
-      property    => "toRna".Str,
-    },
-    {
-      description => "RNA complement".Str,
-      dna         => "ACGTGGTCTTAA".Str,
-      expected    => "UGCACCAGAAUU".Str,
-      property    => "toRna".Str,
-    },
-    {
-      description => "correctly handles invalid input (RNA instead of DNA)".Str,
-      dna         => "U".Str,
-      expected    => (Any),
-      property    => "toRna".Str,
-    },
-    {
-      description => "correctly handles completely invalid DNA input".Str,
-      dna         => "XXX".Str,
-      expected    => (Any),
-      property    => "toRna".Str,
-    },
-    {
-      description => "correctly handles partially invalid DNA input".Str,
-      dna         => "ACGTXXXCTTAA".Str,
-      expected    => (Any),
-      property    => "toRna".Str,
-    },
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "rna-transcription",
+  "version": "1.0.1",
+  "comments": [
+    "Language implementations vary on the issue of invalid input data.",
+    "A language may elect to simplify this task by only presenting valid",
+    "test cases.  For languages handling invalid input data as",
+    "error conditions, invalid test cases are included here and are",
+    "indicated with an expected value of null.  Note however that null is",
+    "simply an indication here in the JSON.  Actually returning null from",
+    "a rna-transcription function may or may not be idiomatic in a language.",
+    "Language idioms of errors or exceptions should be followed.",
+    "Alternative interpretations such as ignoring excess length at the end",
+    "are not represented here."
   ],
-  comments => [
-    "Language implementations vary on the issue of invalid input data.".Str,
-    "A language may elect to simplify this task by only presenting valid".Str,
-    "test cases.  For languages handling invalid input data as".Str,
-    "error conditions, invalid test cases are included here and are".Str,
-    "indicated with an expected value of null.  Note however that null is".Str,
-    "simply an indication here in the JSON.  Actually returning null from".Str,
-    "a rna-transcription function may or may not be idiomatic in a language.".Str,
-    "Language idioms of errors or exceptions should be followed.".Str,
-    "Alternative interpretations such as ignoring excess length at the end".Str,
-    "are not represented here.".Str,
-  ],
-  exercise => "rna-transcription".Str,
-  version  => "1.0.1".Str,
-} }
+  "cases": [
+    {
+      "description": "RNA complement of cytosine is guanine",
+      "property": "toRna",
+      "dna": "C",
+      "expected": "G"
+    },
+    {
+      "description": "RNA complement of guanine is cytosine",
+      "property": "toRna",
+      "dna": "G",
+      "expected": "C"
+    },
+    {
+      "description": "RNA complement of thymine is adenine",
+      "property": "toRna",
+      "dna": "T",
+      "expected": "A"
+    },
+    {
+      "description": "RNA complement of adenine is uracil",
+      "property": "toRna",
+      "dna": "A",
+      "expected": "U"
+    },
+    {
+      "description": "RNA complement",
+      "property": "toRna",
+      "dna": "ACGTGGTCTTAA",
+      "expected": "UGCACCAGAAUU"
+    },
+    {
+      "description": "correctly handles invalid input (RNA instead of DNA)",
+      "property": "toRna",
+      "dna": "U",
+      "expected": null
+    },
+    {
+      "description": "correctly handles completely invalid DNA input",
+      "property": "toRna",
+      "dna": "XXX",
+      "expected": null
+    },
+    {
+      "description": "correctly handles partially invalid DNA input",
+      "property": "toRna",
+      "dna": "ACGTXXXCTTAA",
+      "expected": null
+    }
+  ]
+}
+
+END
+}

--- a/exercises/scrabble-score/scrabble-score.t
+++ b/exercises/scrabble-score/scrabble-score.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Scrabble';
 my $version = v1;
@@ -31,75 +32,81 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "scrabble-score",
+  "version": "1.0.0",
+  "cases": [
     {
-      description => "lowercase letter".Str,
-      expected    => 1.Int,
-      input       => "a".Str,
-      property    => "score".Str,
+      "description": "lowercase letter",
+      "property": "score",
+      "input": "a",
+      "expected": 1
     },
     {
-      description => "uppercase letter".Str,
-      expected    => 1.Int,
-      input       => "A".Str,
-      property    => "score".Str,
+      "description": "uppercase letter",
+      "property": "score",
+      "input": "A",
+      "expected": 1
     },
     {
-      description => "valuable letter".Str,
-      expected    => 4.Int,
-      input       => "f".Str,
-      property    => "score".Str,
+      "description": "valuable letter",
+      "property": "score",
+      "input": "f",
+      "expected": 4
     },
     {
-      description => "short word".Str,
-      expected    => 2.Int,
-      input       => "at".Str,
-      property    => "score".Str,
+      "description": "short word",
+      "property": "score",
+      "input": "at",
+      "expected": 2
     },
     {
-      description => "short, valuable word".Str,
-      expected    => 12.Int,
-      input       => "zoo".Str,
-      property    => "score".Str,
+      "description": "short, valuable word",
+      "property": "score",
+      "input": "zoo",
+      "expected": 12
     },
     {
-      description => "medium word".Str,
-      expected    => 6.Int,
-      input       => "street".Str,
-      property    => "score".Str,
+      "description": "medium word",
+      "property": "score",
+      "input": "street",
+      "expected": 6
     },
     {
-      description => "medium, valuable word".Str,
-      expected    => 22.Int,
-      input       => "quirky".Str,
-      property    => "score".Str,
+      "description": "medium, valuable word",
+      "property": "score",
+      "input": "quirky",
+      "expected": 22
     },
     {
-      description => "long, mixed-case word".Str,
-      expected    => 41.Int,
-      input       => "OxyphenButazone".Str,
-      property    => "score".Str,
+      "description": "long, mixed-case word",
+      "property": "score",
+      "input": "OxyphenButazone",
+      "expected": 41
     },
     {
-      description => "english-like word".Str,
-      expected    => 8.Int,
-      input       => "pinata".Str,
-      property    => "score".Str,
+      "description": "english-like word",
+      "property": "score",
+      "input": "pinata",
+      "expected": 8
     },
     {
-      description => "empty input".Str,
-      expected    => 0.Int,
-      input       => "".Str,
-      property    => "score".Str,
+      "description": "empty input",
+      "property": "score",
+      "input": "",
+      "expected": 0
     },
     {
-      description => "entire alphabet available".Str,
-      expected    => 87.Int,
-      input       => "abcdefghijklmnopqrstuvwxyz".Str,
-      property    => "score".Str,
-    },
-  ],
-  exercise => "scrabble-score".Str,
-  version  => "1.0.0".Str,
-} }
+      "description": "entire alphabet available",
+      "property": "score",
+      "input": "abcdefghijklmnopqrstuvwxyz",
+      "expected": 87
+    }
+  ]
+}
+
+END
+}

--- a/exercises/space-age/space-age.t
+++ b/exercises/space-age/space-age.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'SpaceAge';
 my $version = v1;
@@ -31,65 +32,71 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "space-age",
+  "version": "1.0.0",
+  "cases": [
     {
-      description => "age on Earth".Str,
-      expected    => 31.69.Rat,
-      planet      => "Earth".Str,
-      property    => "age".Str,
-      seconds     => 1000000000.Int,
+      "description": "age on Earth",
+      "property": "age",
+      "planet": "Earth",
+      "seconds": 1000000000,
+      "expected": 31.69
     },
     {
-      description => "age on Mercury".Str,
-      expected    => 280.88.Rat,
-      planet      => "Mercury".Str,
-      property    => "age".Str,
-      seconds     => 2134835688.Int,
+      "description": "age on Mercury",
+      "property": "age",
+      "planet": "Mercury",
+      "seconds": 2134835688,
+      "expected": 280.88
     },
     {
-      description => "age on Venus".Str,
-      expected    => 9.78.Rat,
-      planet      => "Venus".Str,
-      property    => "age".Str,
-      seconds     => 189839836.Int,
+      "description": "age on Venus",
+      "property": "age",
+      "planet": "Venus",
+      "seconds": 189839836,
+      "expected": 9.78
     },
     {
-      description => "age on Mars".Str,
-      expected    => 39.25.Rat,
-      planet      => "Mars".Str,
-      property    => "age".Str,
-      seconds     => 2329871239.Int,
+      "description": "age on Mars",
+      "property": "age",
+      "planet": "Mars",
+      "seconds": 2329871239,
+      "expected": 39.25
     },
     {
-      description => "age on Jupiter".Str,
-      expected    => 2.41.Rat,
-      planet      => "Jupiter".Str,
-      property    => "age".Str,
-      seconds     => 901876382.Int,
+      "description": "age on Jupiter",
+      "property": "age",
+      "planet": "Jupiter",
+      "seconds": 901876382,
+      "expected": 2.41
     },
     {
-      description => "age on Saturn".Str,
-      expected    => 3.23.Rat,
-      planet      => "Saturn".Str,
-      property    => "age".Str,
-      seconds     => 3000000000.Int,
+      "description": "age on Saturn",
+      "property": "age",
+      "planet": "Saturn",
+      "seconds": 3000000000,
+      "expected": 3.23
     },
     {
-      description => "age on Uranus".Str,
-      expected    => 1.21.Rat,
-      planet      => "Uranus".Str,
-      property    => "age".Str,
-      seconds     => 3210123456.Int,
+      "description": "age on Uranus",
+      "property": "age",
+      "planet": "Uranus",
+      "seconds": 3210123456,
+      "expected": 1.21
     },
     {
-      description => "age on Neptune".Str,
-      expected    => 1.58.Rat,
-      planet      => "Neptune".Str,
-      property    => "age".Str,
-      seconds     => 8210123456.Int,
-    },
-  ],
-  exercise => "space-age".Str,
-  version  => "1.0.0".Str,
-} }
+      "description": "age on Neptune",
+      "property": "age",
+      "planet": "Neptune",
+      "seconds": 8210123456,
+      "expected": 1.58
+    }
+  ]
+}
+
+END
+}

--- a/exercises/word-count/word-count.t
+++ b/exercises/word-count/word-count.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'WordCount';
 my $version = v1;
@@ -31,119 +32,125 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
-    {
-      description => "count one word".Str,
-      expected    => {
-        word => 1.Int,
-      },
-      input       => "word".Str,
-      property    => "countwords".Str,
-    },
-    {
-      description => "count one of each word".Str,
-      expected    => {
-        each => 1.Int,
-        of   => 1.Int,
-        one  => 1.Int,
-      },
-      input       => "one of each".Str,
-      property    => "countwords".Str,
-    },
-    {
-      description => "multiple occurrences of a word".Str,
-      expected    => {
-        blue => 1.Int,
-        fish => 4.Int,
-        one  => 1.Int,
-        red  => 1.Int,
-        two  => 1.Int,
-      },
-      input       => "one fish two fish red fish blue fish".Str,
-      property    => "countwords".Str,
-    },
-    {
-      description => "handles cramped lists".Str,
-      expected    => {
-        one   => 1.Int,
-        three => 1.Int,
-        two   => 1.Int,
-      },
-      input       => "one,two,three".Str,
-      property    => "countwords".Str,
-    },
-    {
-      description => "handles expanded lists".Str,
-      expected    => {
-        one   => 1.Int,
-        three => 1.Int,
-        two   => 1.Int,
-      },
-      input       => "one,\ntwo,\nthree".Str,
-      property    => "countwords".Str,
-    },
-    {
-      description => "ignore punctuation".Str,
-      expected    => {
-        as         => 1.Int,
-        car        => 1.Int,
-        carpet     => 1.Int,
-        java       => 1.Int,
-        javascript => 1.Int,
-      },
-      input       => "car: carpet as java: javascript!!\&\@\$\%^\&".Str,
-      property    => "countwords".Str,
-    },
-    {
-      description => "include numbers".Str,
-      expected    => {
-        1       => 1.Int,
-        2       => 1.Int,
-        testing => 2.Int,
-      },
-      input       => "testing, 1, 2 testing".Str,
-      property    => "countwords".Str,
-    },
-    {
-      description => "normalize case".Str,
-      expected    => {
-        go   => 3.Int,
-        stop => 2.Int,
-      },
-      input       => "go Go GO Stop stop".Str,
-      property    => "countwords".Str,
-    },
-    {
-      description => "with apostrophes".Str,
-      expected    => {
-        cry   => 1.Int,
-        don't => 2.Int,
-        first => 1.Int,
-        laugh => 1.Int,
-        then  => 1.Int,
-      },
-      input       => "First: don't laugh. Then: don't cry.".Str,
-      property    => "countwords".Str,
-    },
-    {
-      description => "with quotations".Str,
-      expected    => {
-        and     => 1.Int,
-        between => 1.Int,
-        can't   => 1.Int,
-        joe     => 1.Int,
-        large   => 2.Int,
-        tell    => 1.Int,
-      },
-      input       => "Joe can't tell between 'large' and large.".Str,
-      property    => "countwords".Str,
-    },
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "word-count",
+  "version": "1.0.0",
+  "comments": [
+    "For each word in the input, count the number of times it appears in the",
+    "entire sentence."
   ],
-  comments => [
-    "For each word in the input, count the number of times it appears in the".Str,
-    "entire sentence.".Str,
-  ],
-  exercise => "word-count".Str,
-  version  => "1.0.0".Str,
-} }
+  "cases": [
+    {
+      "description": "count one word",
+      "property": "countwords",
+      "input": "word",
+      "expected": {
+        "word": 1
+      }
+    },
+    {
+      "description": "count one of each word",
+      "property": "countwords",
+      "input": "one of each",
+      "expected": {
+        "one": 1,
+        "of": 1,
+        "each": 1
+      }
+    },
+    {
+      "description": "multiple occurrences of a word",
+      "property": "countwords",
+      "input": "one fish two fish red fish blue fish",
+      "expected": {
+        "one": 1,
+        "fish": 4,
+        "two": 1,
+        "red": 1,
+        "blue": 1
+      }
+    },
+    {
+      "description": "handles cramped lists",
+      "property": "countwords",
+      "input": "one,two,three",
+      "expected": {
+        "one": 1,
+        "two": 1,
+        "three": 1
+      }
+    },
+    {
+      "description": "handles expanded lists",
+      "property": "countwords",
+      "input": "one,\ntwo,\nthree",
+      "expected": {
+        "one": 1,
+        "two": 1,
+        "three": 1
+      }
+    },
+    {
+      "description": "ignore punctuation",
+      "property": "countwords",
+      "input": "car: carpet as java: javascript!!&@$%^&",
+      "expected": {
+        "car": 1,
+        "carpet": 1,
+        "as": 1,
+        "java": 1,
+        "javascript": 1
+      }
+    },
+    {
+      "description": "include numbers",
+      "property": "countwords",
+      "input": "testing, 1, 2 testing",
+      "expected": {
+        "testing": 2,
+        "1": 1,
+        "2": 1
+      }
+    },
+    {
+      "description": "normalize case",
+      "property": "countwords",
+      "input": "go Go GO Stop stop",
+      "expected": {
+        "go": 3,
+        "stop": 2
+      }
+    },
+    {
+      "description": "with apostrophes",
+      "property": "countwords",
+      "input": "First: don't laugh. Then: don't cry.",
+      "expected": {
+        "first": 1,
+        "don't": 2,
+        "laugh": 1,
+        "then": 1,
+        "cry": 1
+      }
+    },
+    {
+      "description": "with quotations",
+      "property": "countwords",
+      "input": "Joe can't tell between 'large' and large.",
+      "expected": {
+        "joe": 1,
+        "can't": 1,
+        "tell": 1,
+        "between": 1,
+        "large": 2,
+        "and": 1
+      }
+    }
+  ]
+}
+
+END
+}

--- a/exercises/wordy/wordy.t
+++ b/exercises/wordy/wordy.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
 
 my $exercise = 'Wordy';
 my $version = v1;
@@ -37,110 +38,116 @@ if %*ENV<EXERCISM> {
 
 done-testing;
 
-INIT { $c-data := {
-  cases    => [
-    {
-      description => "addition".Str,
-      expected    => 2.Int,
-      input       => "What is 1 plus 1?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "more addition".Str,
-      expected    => 55.Int,
-      input       => "What is 53 plus 2?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "addition with negative numbers".Str,
-      expected    => -11.Int,
-      input       => "What is -1 plus -10?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "large addition".Str,
-      expected    => 45801.Int,
-      input       => "What is 123 plus 45678?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "subtraction".Str,
-      expected    => 16.Int,
-      input       => "What is 4 minus -12?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "multiplication".Str,
-      expected    => -75.Int,
-      input       => "What is -3 multiplied by 25?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "division".Str,
-      expected    => -11.Int,
-      input       => "What is 33 divided by -3?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "multiple additions".Str,
-      expected    => 3.Int,
-      input       => "What is 1 plus 1 plus 1?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "addition and subtraction".Str,
-      expected    => 8.Int,
-      input       => "What is 1 plus 5 minus -2?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "multiple subtraction".Str,
-      expected    => 3.Int,
-      input       => "What is 20 minus 4 minus 13?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "subtraction then addition".Str,
-      expected    => 14.Int,
-      input       => "What is 17 minus 6 plus 3?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "multiple multiplication".Str,
-      expected    => -12.Int,
-      input       => "What is 2 multiplied by -2 multiplied by 3?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "addition and multiplication".Str,
-      expected    => -8.Int,
-      input       => "What is -3 plus 7 multiplied by -2?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "multiple division".Str,
-      expected    => 2.Int,
-      input       => "What is -12 divided by 2 divided by -3?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "unknown operation".Str,
-      expected    => Bool::False.Bool,
-      input       => "What is 52 cubed?".Str,
-      property    => "answer".Str,
-    },
-    {
-      description => "Non math question".Str,
-      expected    => Bool::False.Bool,
-      input       => "Who is the President of the United States?".Str,
-      property    => "answer".Str,
-    },
+INIT {
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "wordy",
+  "version": "1.0.0",
+  "comments": [
+    "The tests that expect 'false' should be implemented to raise",
+    "an error, or indicate a failure. Implement this in a way that",
+    "makes sense for your language."
   ],
-  comments => [
-    "The tests that expect 'false' should be implemented to raise".Str,
-    "an error, or indicate a failure. Implement this in a way that".Str,
-    "makes sense for your language.".Str,
-  ],
-  exercise => "wordy".Str,
-  version  => "1.0.0".Str,
-} }
+  "cases": [
+    {
+      "description": "addition",
+      "property": "answer",
+      "input": "What is 1 plus 1?",
+      "expected": 2
+    },
+    {
+      "description": "more addition",
+      "property": "answer",
+      "input": "What is 53 plus 2?",
+      "expected": 55
+    },
+    {
+      "description": "addition with negative numbers",
+      "property": "answer",
+      "input": "What is -1 plus -10?",
+      "expected": -11
+    },
+    {
+      "description": "large addition",
+      "property": "answer",
+      "input": "What is 123 plus 45678?",
+      "expected": 45801
+    },
+    {
+      "description": "subtraction",
+      "property": "answer",
+      "input": "What is 4 minus -12?",
+      "expected": 16
+    },
+    {
+      "description": "multiplication",
+      "property": "answer",
+      "input": "What is -3 multiplied by 25?",
+      "expected": -75
+    },
+    {
+      "description": "division",
+      "property": "answer",
+      "input": "What is 33 divided by -3?",
+      "expected": -11
+    },
+    {
+      "description": "multiple additions",
+      "property": "answer",
+      "input": "What is 1 plus 1 plus 1?",
+      "expected": 3
+    },
+    {
+      "description": "addition and subtraction",
+      "property": "answer",
+      "input": "What is 1 plus 5 minus -2?",
+      "expected": 8
+    },
+    {
+      "description": "multiple subtraction",
+      "property": "answer",
+      "input": "What is 20 minus 4 minus 13?",
+      "expected": 3
+    },
+    {
+      "description": "subtraction then addition",
+      "property": "answer",
+      "input": "What is 17 minus 6 plus 3?",
+      "expected": 14
+    },
+    {
+      "description": "multiple multiplication",
+      "property": "answer",
+      "input": "What is 2 multiplied by -2 multiplied by 3?",
+      "expected": -12
+    },
+    {
+      "description": "addition and multiplication",
+      "property": "answer",
+      "input": "What is -3 plus 7 multiplied by -2?",
+      "expected": -8
+    },
+    {
+      "description": "multiple division",
+      "property": "answer",
+      "input": "What is -12 divided by 2 divided by -3?",
+      "expected": 2
+    },
+    {
+      "description": "unknown operation",
+      "property": "answer",
+      "input": "What is 52 cubed?",
+      "expected": false
+    },
+    {
+      "description": "Non math question",
+      "property": "answer",
+      "input": "Who is the President of the United States?",
+      "expected": false
+    }
+  ]
+}
+
+END
+}

--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -1,9 +1,9 @@
 #!/usr/bin/env perl6
 use v6;{{=#`{{ }}=}}#`{{! Mustache tags double up as Perl 6 embedded comments}}
 use Test;
-use lib #`{{#cdata}}my $dir = #`{{/cdata}}$?FILE.IO.dirname;#`{{#lib_comment}} #`[#`{{&lib_comment}}]#`{{/lib_comment}}
-#`{{#modules}}use #`{{&use}};
-#`{{/modules}}
+use lib #`{{#cdata}}my $dir = #`{{/cdata}}$?FILE.IO.dirname;#`{{#lib_comment}} #`[#`{{&lib_comment}}]#`{{/lib_comment}}#`{{#cdata}}
+use JSON::Fast;#`{{/cdata}}#`{{#modules}}
+use #`{{&use}};#`{{/modules}}
 
 my $exercise#`{{#exercise}} = '#`{{&exercise}}'#`{{/exercise}};#`{{#exercise_comment}} #`[#`{{&exercise_comment}}]#`{{/exercise_comment}}
 my $version#`{{#version}} = v#`{{&version}}#`{{/version}};#`{{#version_comment}} #`[#`{{&version_comment}}]#`{{/version_comment}}
@@ -49,4 +49,9 @@ done-testing;#`{{#done_testing_comment}} #`[#`{{&done_testing_comment}}]#`{{/don
 #`{{#INIT_comment}}
 
 #`[#`{{&INIT_comment}}]#`{{/INIT_comment}}
-INIT { $c-data := #`{{&perl}} }#`{{/cdata}}
+INIT {
+$c-data := from-json q:to/END/;
+
+#`{{&json}}
+END
+}#`{{/cdata}}


### PR DESCRIPTION
With the issues encountered with dumping Perl 5 data from decoded JSON, I'm going to err on the side of caution and go back to using JSON here too. It requires the JSON::Fast module to be installed, but that comes as standard with Rakudo Star so should be seamless for the vast majority of Perl 6 users.