### PR TITLE
Remove redundant key/value pairs from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,5 @@
 {
-  "slug": "perl6",
   "language": "Perl 6",
-  "repository": "https://github.com/exercism/perl6",
   "checklist_issue": 30,
   "active": true,
   "test_pattern": ".*\\.t$",


### PR DESCRIPTION
The slug is not used anywhere. We initialize a track based on knowing the Track ID.
Since the repository is always named after the track ID, this field, too, is redundant,
as it can be inferred.


See https://github.com/exercism/meta/issues/19