### PR TITLE
Add default introductory code example

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,0 +1,14 @@
+#`(
+  This is a 'stub' file. It's a little start on your solution.
+  It is not a complete solution though; you will have to write some code.
+
+  The ':ver<>' adverb defines the version of a module or class.
+  The version is checked in the test suite to ensure the exercise
+  and test suite line up. If the test is updated, it will indicate
+  to others who test your code that some tests may no longer pass.
+)
+unit module HelloWorld:ver<2>;
+
+sub hello is export {
+  'Hello, World!'
+}

--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,13 +1,4 @@
-#`(
-  This is a 'stub' file. It's a little start on your solution.
-  It is not a complete solution though; you will have to write some code.
-
-  The ':ver<>' adverb defines the version of a module or class.
-  The version is checked in the test suite to ensure the exercise
-  and test suite line up. If the test is updated, it will indicate
-  to others who test your code that some tests may no longer pass.
-)
-unit module HelloWorld:ver<2>;
+unit module HelloWorld;
 
 sub hello is export {
   'Hello, World!'


### PR DESCRIPTION
Instead of having logic for a fallback in the backend, we're choosing a
default for the snippet file.

For tracks that have core exercises, we pick the first core exercise.
For tracks without these, we pick the first exercise listed in the config.

Note that we're aiming for 10 lines and a max-width of 40 columns.
This solution has 14 lines and a max-width of 73, so we may want to adjust it.

See https://github.com/exercism/meta/issues/89