### PR TITLE
Travis tweaks for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 ---
 sudo: false
-services:
-  - docker
 before_script:
   - git clone https://github.com/exercism/problem-specifications.git
   - bin/fetch-configlet

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,10 @@ before_script:
   - docker pull rakudo-star:latest
 script:
   - bin/configlet lint .
-  - docker run -e EXERCISM=1 -t -v $PWD:/exercism rakudo-star prove /exercism -re perl6
+  - docker run
+    --env EXERCISM=1
+    --volume $PWD:/exercism
+    rakudo-star prove /exercism
+    --exec perl6
+    --recurse
+    --jobs 2


### PR DESCRIPTION
1. We don't need the services key as the docker service is already running when travis starts.
2. Clearer flags, plus --jobs flag for prove to run tests in parallel and shave off a few seconds.