### PR TITLE
Remove subroutine name interpolation

### DIFF
--- a/exercises/all-your-base/all-your-base.t
+++ b/exercises/all-your-base/all-your-base.t
@@ -41,7 +41,7 @@ for @($c-data<cases>) -> $case {
     is-deeply call-convert-base, $expected, $case<description>
   }
 
-  sub call-convert-base { &::('convert-base')(|$case<input_base input_digits output_base>) }
+  sub call-convert-base { convert-base(|$case<input_base input_digits output_base>) }
 }
 
 if %*ENV<EXERCISM> {

--- a/exercises/all-your-base/example.yaml
+++ b/exercises/all-your-base/example.yaml
@@ -22,7 +22,7 @@ tests: |
       is-deeply call-convert-base, $expected, $case<description>
     }
   
-    sub call-convert-base { &::('convert-base')(|$case<input_base input_digits output_base>) }
+    sub call-convert-base { convert-base(|$case<input_base input_digits output_base>) }
   }
 
 unit: module

--- a/exercises/flatten-array/example.yaml
+++ b/exercises/flatten-array/example.yaml
@@ -3,7 +3,7 @@ version: 1
 plan: 8
 imports: '&flatten-array'
 tests: |
-  is-deeply &::('flatten-array')(.<input>), |.<expected description> for @($c-data<cases>);
+  is-deeply flatten-array(.<input>), |.<expected description> for @($c-data<cases>);
 
 unit: module
 example: |

--- a/exercises/flatten-array/flatten-array.t
+++ b/exercises/flatten-array/flatten-array.t
@@ -22,7 +22,7 @@ if ::($exercise).^ver !~~ $version {
 require ::($module) <&flatten-array>;
 
 my $c-data;
-is-deeply &::('flatten-array')(.<input>), |.<expected description> for @($c-data<cases>);
+is-deeply flatten-array(.<input>), |.<expected description> for @($c-data<cases>);
 
 if %*ENV<EXERCISM> {
   if (my $c-data-file = "$dir/../../problem-specifications/exercises/{$dir.IO.resolve.basename}/canonical-data.json".IO.resolve) ~~ :f {

--- a/exercises/hello-world/example.yaml
+++ b/exercises/hello-world/example.yaml
@@ -5,7 +5,7 @@ imports: '&hello'
 tests: |
   #`[Go through the cases (hiding at the bottom of this file)
   and check that &hello gives us the correct response.]
-  is &::('hello')(), |.<expected description> for @($c-data<cases>);
+  is hello, |.<expected description> for @($c-data<cases>);
 
 exercise_comment: The name of this exercise.
 module_comment: "%*ENV<EXERCISM> is for tests not directly for the exercise, don't worry about these :)"

--- a/exercises/hello-world/hello-world.t
+++ b/exercises/hello-world/hello-world.t
@@ -28,7 +28,7 @@ require ::($module) <&hello>;
 my $c-data;
 #`[Go through the cases (hiding at the bottom of this file)
 and check that &hello gives us the correct response.]
-is &::('hello')(), |.<expected description> for @($c-data<cases>);
+is hello, |.<expected description> for @($c-data<cases>);
 
 #`[Ignore this for your exercise! Tells Exercism folks when exercise cases become out of date.]
 if %*ENV<EXERCISM> {

--- a/exercises/leap/example.yaml
+++ b/exercises/leap/example.yaml
@@ -3,7 +3,7 @@ version: 1
 plan: 6
 imports: '&is-leap-year'
 tests: |
-  is &::('is-leap-year')(.<input>), |.<expected description> for @($c-data<cases>);
+  is is-leap-year(.<input>), |.<expected description> for @($c-data<cases>);
 
 unit: module
 example: |

--- a/exercises/leap/leap.t
+++ b/exercises/leap/leap.t
@@ -22,7 +22,7 @@ if ::($exercise).^ver !~~ $version {
 require ::($module) <&is-leap-year>;
 
 my $c-data;
-is &::('is-leap-year')(.<input>), |.<expected description> for @($c-data<cases>);
+is is-leap-year(.<input>), |.<expected description> for @($c-data<cases>);
 
 if %*ENV<EXERCISM> {
   if (my $c-data-file = "$dir/../../problem-specifications/exercises/{$dir.IO.resolve.basename}/canonical-data.json".IO.resolve) ~~ :f {


### PR DESCRIPTION
This was needed back when `require` was using a variable, but since that is no longer the case we can remove the name interpolation to clean things up.