### PR TITLE
Remove done-testing from test template

### DIFF
--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -36,10 +36,6 @@ subtest 'Class methods', {
 #`{{/methods}}#`{{#cdata}}
 my $c-data;#`{{/cdata}}
 #`{{&tests}}
-
-done-testing;#`{{#done_testing_comment}} #`[#`{{&done_testing_comment}}]#`{{/done_testing_comment}}#`{{#after_done_testing}}
-
-#`{{&after_done_testing}}#`{{/after_done_testing}}
 #`{{#INIT_comment}}
 
 #`[#`{{&INIT_comment}}]#`{{/INIT_comment}}


### PR DESCRIPTION
`done-testing` is not necessary, and I want to have tests after the point where `done-testing` is currently inserted.