### PR TITLE
Move canonical-data to Pod code block

### DIFF
--- a/exercises/accumulate/accumulate.t
+++ b/exercises/accumulate/accumulate.t
@@ -38,6 +38,5 @@ is-deeply accumulate(['a', 'b', 'c' ], sub ($inp) { [ accumulate( [1, 2, 3], sub
 is-deeply accumulate(['the', 'quick', 'brown', 'fox'], sub { @_[0].flip }),
           ['eht', 'kciuq', 'nworb', 'xof'],
           'reverse strings';
-INIT {
-  $module = 'Example' if %*ENV<EXERCISM>;
-}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/all-your-base/all-your-base.t
+++ b/exercises/all-your-base/all-your-base.t
@@ -21,7 +21,7 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&convert-base>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 
 for @($c-data<cases>) -> $case {
   if $case<expected> ~~ Array:D { test }
@@ -44,21 +44,8 @@ for @($c-data<cases>) -> $case {
   sub call-convert-base { convert-base(|$case<input_base input_digits output_base>) }
 }
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "all-your-base",
@@ -255,7 +242,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/allergies/allergies.t
+++ b/exercises/allergies/allergies.t
@@ -21,7 +21,7 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&allergic-to &list-allergies>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>.values -> %case-set {
 
   subtest 'allergic-to' => {
@@ -40,21 +40,8 @@ for $c-data<cases>.values -> %case-set {
 
 }
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "allergies",
@@ -206,7 +193,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/anagram/anagram.t
+++ b/exercises/anagram/anagram.t
@@ -21,24 +21,11 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&match-anagrams>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 is match-anagrams(|.<subject candidates>), |.<expected description> for @($c-data<cases>);
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "anagram",
@@ -171,7 +158,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/atbash-cipher/atbash-cipher.t
+++ b/exercises/atbash-cipher/atbash-cipher.t
@@ -21,7 +21,7 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&encode &decode>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>) {
   my $test = .<description> ~~ 'encode' ?? 'encode' !! 'decode';
   subtest $test => {
@@ -31,21 +31,8 @@ for @($c-data<cases>) {
   }
 }
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "atbash-cipher",
@@ -143,7 +130,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/bob/bob.t
+++ b/exercises/bob/bob.t
@@ -28,28 +28,12 @@ subtest 'Class methods', {
   ok ::($exercise).can($_), $_ for <hey>;
 }
 
-my $c-data;
-#`[Go through all of the cases (hiding at the bottom of this file)
-and check that Bob gives us the correct response for each one.]
+my $c-data = from-json $=pod.pop.contents;
+# Go through the cases and check that Bob gives us the correct responses.
 is ::($exercise).?hey(.<input>), |.<expected description> for @($c-data<cases>);
 
-#`[Don't worry about the stuff below here for your exercise.
-This is for Exercism folks to check that everything is in order.]
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "bob",
@@ -208,7 +192,21 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+#`[Don't worry about the stuff below here for your exercise.
+This is for Exercism folks to check that everything is in order.]
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/bob/example.yaml
+++ b/exercises/bob/example.yaml
@@ -3,8 +3,7 @@ version: 1
 plan: 28
 methods: hey
 tests: |
-  #`[Go through all of the cases (hiding at the bottom of this file)
-  and check that Bob gives us the correct response for each one.]
+  # Go through the cases and check that Bob gives us the correct responses.
   is ::($exercise).?hey(.<input>), |.<expected description> for @($c-data<cases>);
 
 exercise_comment: The name of this exercise.

--- a/exercises/clock/clock.t
+++ b/exercises/clock/clock.t
@@ -23,7 +23,7 @@ subtest 'Class methods', {
   ok ::($exercise).can($_), $_ for <time add-minutes>;
 }
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>) {
   for @(.<cases>) -> $case {
     given $case<property> {
@@ -48,21 +48,8 @@ for @($c-data<cases>) {
 todo 'optional test' unless %*ENV<EXERCISM>;
 is ::($exercise).new(:0hour,:0minute).?add-minutes(65).?time, '01:05', 'add-minutes method can be chained';
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "clock",
@@ -554,7 +541,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/flatten-array/flatten-array.t
+++ b/exercises/flatten-array/flatten-array.t
@@ -21,24 +21,11 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&flatten-array>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 is-deeply flatten-array(.<input>), |.<expected description> for @($c-data<cases>);
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "flatten-array",
@@ -83,7 +70,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/grade-school/grade-school.t
+++ b/exercises/grade-school/grade-school.t
@@ -38,6 +38,5 @@ subtest 'Additional students', {
   ok $roster.?add-student(:name($_), :3grade), "Add $_ to grade 3" for <Tom Dick Harry>;
 }
 is $roster.?list-all, ('Grade 1', <Anna Barb Charlie>, 'Grade 2', <Alex Jim Zoe>, 'Grade 3', <Dick Harry Tom>), 'List all';
-INIT {
-  $module = 'Example' if %*ENV<EXERCISM>;
-}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/grains/grains.t
+++ b/exercises/grains/grains.t
@@ -21,7 +21,7 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&grains-on-square &total-grains>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>[0]<cases>) {
   if .<expected> == -1 {
     throws-like { grains-on-square(.<input>) }, Exception, .<description>;
@@ -31,21 +31,8 @@ for @($c-data<cases>[0]<cases>) {
 }
 is total-grains, |$c-data<cases>[1]<expected description>;
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "grains",
@@ -129,7 +116,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/hello-world/example.yaml
+++ b/exercises/hello-world/example.yaml
@@ -3,8 +3,7 @@ version: 2
 plan: 3
 imports: '&hello'
 tests: |
-  #`[Go through the cases (hiding at the bottom of this file)
-  and check that &hello gives us the correct response.]
+  # Go through the cases and check that &hello gives us the correct response.
   is hello, |.<expected description> for @($c-data<cases>);
 
 exercise_comment: The name of this exercise.

--- a/exercises/hello-world/hello-world.t
+++ b/exercises/hello-world/hello-world.t
@@ -25,10 +25,26 @@ if ::($exercise).^ver !~~ $version {
 #`[Import '&hello' from 'HelloWorld']
 require ::($module) <&hello>;
 
-my $c-data;
-#`[Go through the cases (hiding at the bottom of this file)
-and check that &hello gives us the correct response.]
+my $c-data = from-json $=pod.pop.contents;
+# Go through the cases and check that &hello gives us the correct response.
 is hello, |.<expected description> for @($c-data<cases>);
+
+=head2 Canonical Data
+=begin code
+
+{
+  "exercise": "hello-world",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "description": "Say Hi!",
+      "property": "hello",
+      "expected": "Hello, World!"
+    }
+  ]
+}
+
+=end code
 
 #`[Don't worry about the stuff below here for your exercise.
 This is for Exercism folks to check that everything is in order.]
@@ -45,22 +61,4 @@ subtest 'canonical-data' => {
     flunk 'problem-specifications file not found';
 }
 
-INIT {
-$c-data := from-json q:to/END/;
-
-{
-  "exercise": "hello-world",
-  "version": "1.0.0",
-  "cases": [
-    {
-      "description": "Say Hi!",
-      "property": "hello",
-      "expected": "Hello, World!"
-    }
-  ]
-}
-
-END
-
-  $module = 'Example' if %*ENV<EXERCISM>;
-}
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/leap/leap.t
+++ b/exercises/leap/leap.t
@@ -21,24 +21,11 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&is-leap-year>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 is is-leap-year(.<input>), |.<expected description> for @($c-data<cases>);
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "leap",
@@ -71,7 +58,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/linked-list/linked-list.t
+++ b/exercises/linked-list/linked-list.t
@@ -97,6 +97,5 @@ for $cases.values -> $case {
   }
 ]
 =end code
-INIT {
-  $module = 'Example' if %*ENV<EXERCISM>;
-}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/luhn/luhn.t
+++ b/exercises/luhn/luhn.t
@@ -21,24 +21,11 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&is-luhn-valid>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 is .<input>.&is-luhn-valid, |.<expected description> for @($c-data<cases>);
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "luhn",
@@ -125,7 +112,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/phone-number/phone-number.t
+++ b/exercises/phone-number/phone-number.t
@@ -21,7 +21,7 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&clean-number>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>[0]<cases>) {
   if .<expected> {
     is clean-number(.<phrase>), |.<expected description>;
@@ -30,21 +30,8 @@ for @($c-data<cases>[0]<cases>) {
   }
 }
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "phone-number",
@@ -135,7 +122,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/raindrops/raindrops.t
+++ b/exercises/raindrops/raindrops.t
@@ -21,7 +21,7 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&convert>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>) {
   subtest {
     plan 2;
@@ -30,21 +30,8 @@ for @($c-data<cases>) {
   }
 }
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "raindrops",
@@ -161,7 +148,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/rna-transcription/rna-transcription.t
+++ b/exercises/rna-transcription/rna-transcription.t
@@ -21,7 +21,7 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&to-rna>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>) {
   if .<expected> {
     is .<dna>.&to-rna, |.<expected description>;
@@ -30,21 +30,8 @@ for @($c-data<cases>) {
   }
 }
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "rna-transcription",
@@ -113,7 +100,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/robot-name/robot-name.t
+++ b/exercises/robot-name/robot-name.t
@@ -46,6 +46,5 @@ subtest 'Randomness', {
   isnt @names, @names.sort, 'Names not ordered';
   isnt @names, @names.sort.reverse, 'Names not reverse ordered';
 }
-INIT {
-  $module = 'Example' if %*ENV<EXERCISM>;
-}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/scrabble-score/scrabble-score.t
+++ b/exercises/scrabble-score/scrabble-score.t
@@ -21,24 +21,11 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&score>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 is .<input>.&score, |.<expected description> for @($c-data<cases>);
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "scrabble-score",
@@ -113,7 +100,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/space-age/space-age.t
+++ b/exercises/space-age/space-age.t
@@ -21,24 +21,11 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <Mercury Venus Earth Mars Jupiter Saturn Uranus Neptune>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 is (age-on ::(.<planet>): .<seconds>), |.<expected description> for @($c-data<cases>);
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "space-age",
@@ -103,7 +90,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/word-count/word-count.t
+++ b/exercises/word-count/word-count.t
@@ -21,24 +21,11 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&count-words>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 is-deeply (% = .<input>.&count-words), |.<expected description> for @($c-data<cases>);
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "word-count",
@@ -157,7 +144,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/wordy/wordy.t
+++ b/exercises/wordy/wordy.t
@@ -21,7 +21,7 @@ if ::($exercise).^ver !~~ $version {
 
 require ::($module) <&answer>;
 
-my $c-data;
+my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>) {
   if .<expected> === False {
     throws-like {.<input>.&answer}, Exception, .<description>;
@@ -30,21 +30,8 @@ for @($c-data<cases>) {
   }
 }
 
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT {
-$c-data := from-json q:to/END/;
+=head2 Canonical Data
+=begin code
 
 {
   "exercise": "wordy",
@@ -154,7 +141,19 @@ $c-data := from-json q:to/END/;
   ]
 }
 
-END
+=end code
 
-  $module = 'Example' if %*ENV<EXERCISM>;
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
 }
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -32,8 +32,15 @@ subtest 'Class methods', {
   ok ::($exercise).can($_), $_ for <#`{{&methods}}>;
 }
 #`{{/methods}}#`{{#cdata}}
-my $c-data;#`{{/cdata}}
+my $c-data = from-json $=pod.pop.contents;#`{{/cdata}}
 #`{{&tests}}
+#`{{#cdata}}
+
+=head2 Canonical Data
+=begin code
+
+#`{{&json}}
+=end code#`{{/cdata}}
 #`{{#exercism_comment}}
 
 #`[#`{{&exercism_comment}}]#`{{/exercism_comment}}#`{{#cdata}}
@@ -51,12 +58,4 @@ subtest 'canonical-data' => {
 }
 
 #`{{/cdata}}
-INIT {#`{{#cdata}}
-$c-data := from-json q:to/END/;
-
-#`{{&json}}
-END
-#`{{/cdata}}
-
-  $module = 'Example' if %*ENV<EXERCISM>;
-}
+INIT { $module = 'Example' if %*ENV<EXERCISM> }


### PR DESCRIPTION
This allows the canonical data to be viewed with the `perl6 --doc filename.t` command, alongside any other documentation we may include in the exercises.