### PR TITLE
Add etl exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -59,6 +59,16 @@
       ]
     },
     {
+      "uuid": "55a3094e-06b3-4880-3b57-31e5899b99548604cf6",
+      "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+
+      ]
+    },
+    {
       "uuid": "9fc9b102-185d-4f34-98d0-e3084399610a",
       "slug": "clock",
       "core": false,

--- a/exercises/etl/ETL.pm6
+++ b/exercises/etl/ETL.pm6
@@ -1,0 +1,6 @@
+unit module ETL:ver<1>;
+
+no precompilation;
+
+sub transform (%input) is export {
+}

--- a/exercises/etl/Example.pm6
+++ b/exercises/etl/Example.pm6
@@ -1,0 +1,7 @@
+unit module ETL:ver<1>;
+
+no precompilation;
+
+sub transform ( Hash[Array[Str:D], Int:D] $_ --> Hash[Int:D, Str:D] ) is export {
+  Hash[Int:D, Str:D].new: .invert».&{ .key.lc => .value }
+}

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,0 +1,72 @@
+# ETL
+
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
+### ETL
+
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
+we're going to migrate this."
+
+(Typically, this is followed by, "We're only going to need to run this
+once." That's then typically followed by much forehead slapping and
+moaning about how stupid we could possibly be.)
+
+### The goal
+
+We're going to extract some scrabble scores from a legacy system.
+
+The old system stored a list of letters per score:
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+The shiny new scrabble system instead stores the score per letter, which
+makes it much faster and easier to calculate the score for a word. It
+also stores the letters in lower-case regardless of the case of the
+input letters:
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- Etc.
+
+Your mission, should you choose to accept it, is to transform the legacy data
+format to the shiny new format.
+
+### Notes
+
+A final note about scoring, Scrabble is played around the world in a
+variety of languages, each with its own unique scoring table. For
+example, an "E" is scored at 2 in the Māori-language version of the
+game while being scored at 4 in the Hawaiian-language version.
+
+## Resources
+
+Remember to check out the Perl 6 [documentation](https://docs.perl6.org/) and
+[resources](https://perl6.org/resources/) pages for information, tips, and
+examples if you get stuck.
+
+## Running the tests
+
+There is a test suite and module included with the exercise.
+The test suite (a file with the extension `.t`) will attempt to run routines
+from the module (a file with the extension `.pm6`).
+Add/modify routines in the module so that the tests will pass! You can view the
+test data by executing the command `perl6 --doc *.t` (\* being the name of the
+test suite), and run the test suite for the exercise by executing the command
+`prove . --exec=perl6` in the exercise directory.
+You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
+tests, including any optional tests marked as 'TODO'.
+
+## Source
+
+The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/etl.t
+++ b/exercises/etl/etl.t
@@ -1,0 +1,139 @@
+#!/usr/bin/env perl6
+use v6;
+use Test;
+use lib my $dir = $?FILE.IO.dirname;
+use JSON::Fast;
+
+my Str:D $exercise := 'ETL';
+my Version:D $version = v1;
+my Str $module //= $exercise;
+plan 6;
+
+use-ok $module or bail-out;
+require ::($module);
+
+if ::($exercise).^ver !~~ $version {
+  warn "\nExercise version mismatch. Further tests may fail!"
+    ~ "\n$exercise is $(::($exercise).^ver.gist). "
+    ~ "Test is $($version.gist).\n";
+  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+}
+
+require ::($module) <&transform>;
+
+my $c-data = from-json $=pod.pop.contents;
+=head2 Notes
+=begin para
+The test expects your returned C<Hash> to have
+L<type constraints|https://docs.perl6.org/type/Hash#Constraint_value_types>.
+Defined C<Str>s for the values, and defined C<Int>s for the keys.
+=end para
+for $c-data<cases>.values -> %case-set {
+  is-deeply(
+    transform(Hash[Array[Str:D], Int:D].new(
+      .<input>.pairs».&{
+        .key.Int => Array[Str:D](.value.Slip)
+      }
+    )),
+    Hash[Int:D, Str:D].new(.<expected>.pairs),
+    .<description>
+  ) for %case-set<cases>.values;
+}
+
+=head2 Canonical Data
+=begin code
+
+{
+  "exercise": "etl",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "comments": [
+        "Note:  The expected input data for these tests should have",
+        "integer keys (not stringified numbers as shown in the JSON below",
+        "Unless the language prohibits that, please implement these tests",
+        "such that keys are integers. e.g. in JavaScript, it might look ",
+        "like `transform( { 1: ['A'] } );`"
+      ],
+      "description": "transforms the a set of scrabble data previously indexed by the tile score to a set of data indexed by the tile letter",
+      "cases": [
+        {
+          "description": "a single letter",
+          "property": "transform",
+          "input": {
+            "1": ["A"]
+          },
+          "expected": {
+            "a": 1
+          }
+        },
+        {
+          "description": "single score with multiple letters",
+          "property": "transform",
+          "input": {
+            "1": ["A", "E", "I", "O", "U"]
+          },
+          "expected": {
+            "a": 1,
+            "e": 1,
+            "i": 1,
+            "o": 1,
+            "u": 1
+          }
+        },
+        {
+          "description": "multiple scores with multiple letters",
+          "property": "transform",
+          "input": {
+            "1": ["A", "E"],
+            "2": ["D", "G"]
+          },
+          "expected": {
+            "a": 1,
+            "d": 2,
+            "e": 1,
+            "g": 2
+          }
+        },
+        {
+          "description": "multiple scores with differing numbers of letters",
+          "property": "transform",
+          "input": {
+             "1": ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
+             "2": ["D", "G"],
+             "3": ["B", "C", "M", "P"],
+             "4": ["F", "H", "V", "W", "Y"],
+             "5": ["K"],
+             "8": ["J", "X"],
+            "10": ["Q", "Z"]
+          },
+          "expected": {
+            "a":  1, "b":  3, "c": 3, "d": 2, "e": 1,
+            "f":  4, "g":  2, "h": 4, "i": 1, "j": 8,
+            "k":  5, "l":  1, "m": 3, "n": 1, "o": 1,
+            "p":  3, "q": 10, "r": 1, "s": 1, "t": 1,
+            "u":  1, "v":  4, "w": 4, "x": 8, "y": 4,
+            "z": 10
+          }
+        }
+      ]
+    }
+  ]
+}
+
+=end code
+
+unless %*ENV<EXERCISM> {
+  skip-rest 'exercism tests';
+  exit;
+}
+
+subtest 'canonical-data' => {
+  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
+    $dir.IO.resolve.basename
+  }/canonical-data.json".IO.resolve) ~~ :f ??
+    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
+    flunk 'problem-specifications file not found';
+}
+
+INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/etl/example.yaml
+++ b/exercises/etl/example.yaml
@@ -1,0 +1,35 @@
+exercise: ETL
+version: 1
+plan: 6
+imports: '&transform'
+tests: |-
+  =head2 Notes
+  =begin para
+  The test expects your returned C<Hash> to have
+  L<type constraints|https://docs.perl6.org/type/Hash#Constraint_value_types>.
+  Defined C<Str>s for the values, and defined C<Int>s for the keys.
+  =end para
+  for $c-data<cases>.values -> %case-set {
+    is-deeply(
+      transform(Hash[Array[Str:D], Int:D].new(
+        .<input>.pairs».&{
+          .key.Int => Array[Str:D](.value.Slip)
+        }
+      )),
+      Hash[Int:D, Str:D].new(.<expected>.pairs),
+      .<description>
+    ) for %case-set<cases>.values;
+  }
+
+unit: module
+example: |-
+  no precompilation;
+
+  sub transform ( Hash[Array[Str:D], Int:D] $_ --> Hash[Int:D, Str:D] ) is export {
+    Hash[Int:D, Str:D].new: .invert».&{ .key.lc => .value }
+  }
+stub: |-
+  no precompilation;
+
+  sub transform (%input) is export {
+  }


### PR DESCRIPTION
The `no precompilation` pragma is necessary due to a bug preventing typed object comparisons from working correctly without it. Since the exercise is explicit about the typing of the input, I've set it up so that explicit typing is required for the output.