### PR TITLE
Improve bool tests

### DIFF
--- a/exercises/allergies/Allergies.pm6
+++ b/exercises/allergies/Allergies.pm6
@@ -1,1 +1,1 @@
-unit module Allergies:ver<2>;
+unit module Allergies:ver<3>;

--- a/exercises/allergies/Example.pm6
+++ b/exercises/allergies/Example.pm6
@@ -1,4 +1,4 @@
-unit module Allergies:ver<2>;
+unit module Allergies:ver<3>;
 
 our @allergens = <
     eggs

--- a/exercises/allergies/allergies.t
+++ b/exercises/allergies/allergies.t
@@ -5,7 +5,7 @@ use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
 
 my Str:D $exercise := 'Allergies';
-my Version:D $version = v2;
+my Version:D $version = v3;
 my Str $module //= $exercise;
 plan 4;
 
@@ -27,7 +27,15 @@ for $c-data<cases>.values -> %case-set {
   subtest 'allergic-to' => {
     plan 7;
     for %case-set<cases>.values -> %case {
-      is allergic-to(%case<score>, .<substance>), .<result>, %case<description> ~ ': ' ~ .<substance> for %case<expected>.values;
+      for %case<expected>.values {
+        given allergic-to %case<score>, .<substance> -> $result {
+          subtest %case<description> ~ ': ' ~ .<substance> => {
+            plan 2;
+            isa-ok $result, Bool;
+            is-deeply $result, .<result>, 'Result matches expected';
+          }
+        }
+      }
     }
   } when %case-set<description> ~~ 'allergicTo';
 

--- a/exercises/allergies/example.yaml
+++ b/exercises/allergies/example.yaml
@@ -1,5 +1,5 @@
 exercise: Allergies
-version: 2
+version: 3
 plan: 4
 imports: '&allergic-to &list-allergies'
 tests: |-
@@ -8,7 +8,15 @@ tests: |-
     subtest 'allergic-to' => {
       plan 7;
       for %case-set<cases>.values -> %case {
-        is allergic-to(%case<score>, .<substance>), .<result>, %case<description> ~ ': ' ~ .<substance> for %case<expected>.values;
+        for %case<expected>.values {
+          given allergic-to %case<score>, .<substance> -> $result {
+            subtest %case<description> ~ ': ' ~ .<substance> => {
+              plan 2;
+              isa-ok $result, Bool;
+              is-deeply $result, .<result>, 'Result matches expected';
+            }
+          }
+        }
       }
     } when %case-set<description> ~~ 'allergicTo';
 

--- a/exercises/leap/Example.pm6
+++ b/exercises/leap/Example.pm6
@@ -1,4 +1,4 @@
-unit module Leap:ver<2>;
+unit module Leap:ver<3>;
 
 sub is-leap-year ($year) is export {
   is-divisible($year, 400)

--- a/exercises/leap/Leap.pm6
+++ b/exercises/leap/Leap.pm6
@@ -1,4 +1,4 @@
-unit module Leap:ver<2>;
+unit module Leap:ver<3>;
 
 sub is-leap-year ($year) is export {
 }

--- a/exercises/leap/example.yaml
+++ b/exercises/leap/example.yaml
@@ -1,9 +1,17 @@
 exercise: Leap
-version: 2
+version: 3
 plan: 6
 imports: '&is-leap-year'
 tests: |-
-  is is-leap-year(.<input>), |.<expected description> for @($c-data<cases>);
+  for $c-data<cases>.values {
+    given is-leap-year .<input> -> $result {
+      subtest .<description>, {
+        plan 2;
+        isa-ok $result, Bool;
+        is-deeply $result, .<expected>, 'Result matches expected';
+      }
+    }
+  }
 
 unit: module
 example: |-

--- a/exercises/leap/leap.t
+++ b/exercises/leap/leap.t
@@ -5,7 +5,7 @@ use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
 
 my Str:D $exercise := 'Leap';
-my Version:D $version = v2;
+my Version:D $version = v3;
 my Str $module //= $exercise;
 plan 6;
 
@@ -22,7 +22,15 @@ if ::($exercise).^ver !~~ $version {
 require ::($module) <&is-leap-year>;
 
 my $c-data = from-json $=pod.pop.contents;
-is is-leap-year(.<input>), |.<expected description> for @($c-data<cases>);
+for $c-data<cases>.values {
+  given is-leap-year .<input> -> $result {
+    subtest .<description>, {
+      plan 2;
+      isa-ok $result, Bool;
+      is-deeply $result, .<expected>, 'Result matches expected';
+    }
+  }
+}
 
 =head2 Canonical Data
 =begin code

--- a/exercises/luhn/Example.pm6
+++ b/exercises/luhn/Example.pm6
@@ -1,4 +1,4 @@
-unit module Luhn:ver<1>;
+unit module Luhn:ver<2>;
 
 sub is-luhn-valid ($input is copy) is export {
   $input ~~ s:g/\s+//;

--- a/exercises/luhn/Luhn.pm6
+++ b/exercises/luhn/Luhn.pm6
@@ -1,4 +1,4 @@
-unit module Luhn:ver<1>;
+unit module Luhn:ver<2>;
 
 sub is-luhn-valid ($input) is export {
 }

--- a/exercises/luhn/example.yaml
+++ b/exercises/luhn/example.yaml
@@ -1,9 +1,17 @@
 exercise: Luhn
-version: 1
+version: 2
 plan: 15
 imports: '&is-luhn-valid'
 tests: |-
-  is .<input>.&is-luhn-valid, |.<expected description> for @($c-data<cases>);
+  for $c-data<cases>.values {
+    given is-luhn-valid .<input> -> $result {
+      subtest .<description>, {
+        plan 2;
+        isa-ok $result, Bool;
+        is-deeply $result, .<expected>, 'Result matches expected';
+      }
+    }
+  }
 
 unit: module
 example: |-

--- a/exercises/luhn/luhn.t
+++ b/exercises/luhn/luhn.t
@@ -5,7 +5,7 @@ use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
 
 my Str:D $exercise := 'Luhn';
-my Version:D $version = v1;
+my Version:D $version = v2;
 my Str $module //= $exercise;
 plan 15;
 
@@ -22,7 +22,15 @@ if ::($exercise).^ver !~~ $version {
 require ::($module) <&is-luhn-valid>;
 
 my $c-data = from-json $=pod.pop.contents;
-is .<input>.&is-luhn-valid, |.<expected description> for @($c-data<cases>);
+for $c-data<cases>.values {
+  given is-luhn-valid .<input> -> $result {
+    subtest .<description>, {
+      plan 2;
+      isa-ok $result, Bool;
+      is-deeply $result, .<expected>, 'Result matches expected';
+    }
+  }
+}
 
 =head2 Canonical Data
 =begin code

--- a/exercises/pangram/Example.pm6
+++ b/exercises/pangram/Example.pm6
@@ -1,4 +1,4 @@
-unit module Pangram:ver<1>;
+unit module Pangram:ver<2>;
 
 sub is-pangram (Str:D $string --> Bool:D) is export {
   $string.lc.comb ⊇ ‘a’..‘z’

--- a/exercises/pangram/Pangram.pm6
+++ b/exercises/pangram/Pangram.pm6
@@ -1,4 +1,4 @@
-unit module Pangram:ver<1>;
+unit module Pangram:ver<2>;
 
 sub is-pangram ($string) is export {
 }

--- a/exercises/pangram/example.yaml
+++ b/exercises/pangram/example.yaml
@@ -1,10 +1,16 @@
 exercise: Pangram
-version: 1
+version: 2
 plan: 12
 imports: '&is-pangram'
 tests: |-
-  for $c-data<cases>.values -> %case-set {
-    is is-pangram(.<input>), |.<expected description> for %case-set<cases>.values;
+  for $c-data<cases>».<cases>».Array.flat {
+    given is-pangram .<input> -> $result {
+      subtest .<description>, {
+        plan 2;
+        isa-ok $result, Bool;
+        is-deeply $result, .<expected>, 'Result matches expected';
+      }
+    }
   }
 
 unit: module

--- a/exercises/pangram/pangram.t
+++ b/exercises/pangram/pangram.t
@@ -5,7 +5,7 @@ use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
 
 my Str:D $exercise := 'Pangram';
-my Version:D $version = v1;
+my Version:D $version = v2;
 my Str $module //= $exercise;
 plan 12;
 
@@ -22,8 +22,14 @@ if ::($exercise).^ver !~~ $version {
 require ::($module) <&is-pangram>;
 
 my $c-data = from-json $=pod.pop.contents;
-for $c-data<cases>.values -> %case-set {
-  is is-pangram(.<input>), |.<expected description> for %case-set<cases>.values;
+for $c-data<cases>».<cases>».Array.flat {
+  given is-pangram .<input> -> $result {
+    subtest .<description>, {
+      plan 2;
+      isa-ok $result, Bool;
+      is-deeply $result, .<expected>, 'Result matches expected';
+    }
+  }
 }
 
 =head2 Canonical Data


### PR DESCRIPTION
It is currently possible to cheat boolean tests by returning the following junction:
```perl6
True|False
```
Additional tests have been added to check that the type of the returned object is a Bool.