### PR TITLE
Remove messages from exception tests

### DIFF
--- a/exercises/hamming/Example.pm6
+++ b/exercises/hamming/Example.pm6
@@ -1,6 +1,7 @@
-unit module Hamming:ver<1>;
+unit module Hamming:ver<2>;
 
-sub hamming-distance ( Str:D $strand1, Str:D $strand2 --> Int:D ) is export {
-  die ‘left and right strands must be of equal length’ if $strand1.chars ≠ $strand2.chars;
-  ($strand1.comb Zne $strand2.comb).sum
+sub hamming-distance (
+  +@strands where { .elems == 2 && [==] $_».chars } --> Int:D
+) is export {
+  sum [Zne] @strands».comb
 }

--- a/exercises/hamming/Hamming.pm6
+++ b/exercises/hamming/Hamming.pm6
@@ -1,4 +1,4 @@
-unit module Hamming:ver<1>;
+unit module Hamming:ver<2>;
 
 sub hamming-distance ($strand1, $strand2) is export {
 }

--- a/exercises/hamming/example.yaml
+++ b/exercises/hamming/example.yaml
@@ -1,11 +1,11 @@
 exercise: Hamming
-version: 1
+version: 2
 plan: 17
 imports: '&hamming-distance'
 tests: |-
   for $c-data<cases>.values {
     if .<expected><error> {
-      throws-like {hamming-distance(|.<strand1 strand2>)}, Exception, .<description>, message => .<expected><error>;
+      throws-like {hamming-distance(|.<strand1 strand2>)}, Exception, .<description>;
     } else {
       is hamming-distance(|.<strand1 strand2>), |.<expected description>;
     }
@@ -13,9 +13,10 @@ tests: |-
 
 unit: module
 example: |-
-  sub hamming-distance ( Str:D $strand1, Str:D $strand2 --> Int:D ) is export {
-    die ‘left and right strands must be of equal length’ if $strand1.chars ≠ $strand2.chars;
-    ($strand1.comb Zne $strand2.comb).sum
+  sub hamming-distance (
+    +@strands where { .elems == 2 && [==] $_».chars } --> Int:D
+  ) is export {
+    sum [Zne] @strands».comb
   }
 stub: |-
   sub hamming-distance ($strand1, $strand2) is export {

--- a/exercises/hamming/hamming.t
+++ b/exercises/hamming/hamming.t
@@ -5,7 +5,7 @@ use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
 
 my Str:D $exercise := 'Hamming';
-my Version:D $version = v1;
+my Version:D $version = v2;
 my Str $module //= $exercise;
 plan 17;
 
@@ -24,7 +24,7 @@ require ::($module) <&hamming-distance>;
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>.values {
   if .<expected><error> {
-    throws-like {hamming-distance(|.<strand1 strand2>)}, Exception, .<description>, message => .<expected><error>;
+    throws-like {hamming-distance(|.<strand1 strand2>)}, Exception, .<description>;
   } else {
     is hamming-distance(|.<strand1 strand2>), |.<expected description>;
   }


### PR DESCRIPTION
Putting the message in an exception doesn't really add much to an exercise, and limits other ways of throwing exceptions for invalid data e.g. type constraints.