### PR TITLE
Remove exercism variables/conditionals from all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,14 @@ before_script:
   - git clone https://github.com/exercism/problem-specifications.git
   - bin/fetch-configlet
   - docker build -t exercism-rakudo-star .
+  - docker run
+    --volume $PWD:/exercism
+    exercism-rakudo-star perl6 -e
+    '.add(‘Example.pm6’).copy(.dir.first({.extension eq ‘pm6’ && .basename ne ‘Example.pm6’}))
+    for $*CWD.add(‘exercism/exercises’).dir' # replace stub files with complete solutions from Example.pm6
 script:
   - bin/configlet lint .
   - docker run
-    --env EXERCISM=1
     --volume $PWD:/exercism
     exercism-rakudo-star prove /exercism
     --exec perl6

--- a/exercises/accumulate/Accumulate.pm6
+++ b/exercises/accumulate/Accumulate.pm6
@@ -1,1 +1,1 @@
-unit module Accumulate:ver<1>;
+unit module Accumulate:ver<2>;

--- a/exercises/accumulate/Example.pm6
+++ b/exercises/accumulate/Example.pm6
@@ -1,4 +1,4 @@
-unit module Accumulate:ver<1>;
+unit module Accumulate:ver<2>;
 
 sub accumulate (@list, $function) is export {
   my @accumulated;

--- a/exercises/accumulate/accumulate.t
+++ b/exercises/accumulate/accumulate.t
@@ -2,23 +2,16 @@
 use v6;
 use Test;
 use lib $?FILE.IO.dirname;
+use Accumulate;
+plan 6;
 
-my Str:D $exercise := 'Accumulate';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 7;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Accumulate.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nAccumulate is {Accumulate.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&accumulate>;
 
 is-deeply accumulate([ ], sub {}),
           [ ],
@@ -38,5 +31,3 @@ is-deeply accumulate(['a', 'b', 'c' ], sub ($inp) { [ accumulate( [1, 2, 3], sub
 is-deeply accumulate(['the', 'quick', 'brown', 'fox'], sub { @_[0].flip }),
           ['eht', 'kciuq', 'nworb', 'xof'],
           'reverse strings';
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/accumulate/example.yaml
+++ b/exercises/accumulate/example.yaml
@@ -1,7 +1,6 @@
 exercise: Accumulate
-version: 1
-plan: 7
-imports: '&accumulate'
+version: 2
+plan: 6
 tests: |-
   is-deeply accumulate([ ], sub {}),
             [ ],

--- a/exercises/acronym/Acronym.pm6
+++ b/exercises/acronym/Acronym.pm6
@@ -1,4 +1,4 @@
-unit module Acronym:ver<1>;
+unit module Acronym:ver<2>;
 
 sub abbreviate ($phrase) is export {
 }

--- a/exercises/acronym/Example.pm6
+++ b/exercises/acronym/Example.pm6
@@ -1,4 +1,4 @@
-unit module Acronym:ver<1>;
+unit module Acronym:ver<2>;
 
 sub abbreviate ($phrase) is export {
   [~] $phrase.uc.comb(/\w+/).map: *.substr(0, 1);

--- a/exercises/acronym/acronym.t
+++ b/exercises/acronym/acronym.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Acronym;
+plan 6;
 
-my Str:D $exercise := 'Acronym';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 8;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Acronym.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nAcronym is {Acronym.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&abbreviate>;
 
 my $c-data = from-json $=pod.pop.contents;
 
@@ -91,18 +84,3 @@ for $c-data<cases>»<cases>».Array.flat {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/acronym/example.yaml
+++ b/exercises/acronym/example.yaml
@@ -1,7 +1,6 @@
 exercise: Acronym
-version: 1
-plan: 8
-imports: '&abbreviate'
+version: 2
+plan: 6
 tests: |-
 
   for $c-data<cases>»<cases>».Array.flat {

--- a/exercises/all-your-base/AllYourBase.pm6
+++ b/exercises/all-your-base/AllYourBase.pm6
@@ -1,4 +1,4 @@
-unit module AllYourBase:ver<3>;
+unit module AllYourBase:ver<4>;
 
 sub convert-base (:%bases!, :@digits!) is export {
 }

--- a/exercises/all-your-base/Example.pm6
+++ b/exercises/all-your-base/Example.pm6
@@ -1,4 +1,4 @@
-unit module AllYourBase:ver<3>;
+unit module AllYourBase:ver<4>;
 
 sub convert-base (
   :%bases! where all(.keys ~~ <from to>.Set, .values.all > 1),

--- a/exercises/all-your-base/all-your-base.t
+++ b/exercises/all-your-base/all-your-base.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use AllYourBase;
+plan 21;
 
-my Str:D $exercise := 'AllYourBase';
-my Version:D $version = v3;
-my Str $module //= $exercise;
-plan 23;
+my Version:D $version = v4;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if AllYourBase.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nAllYourBase is {AllYourBase.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&convert-base>;
 
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>.values -> $case {
@@ -272,18 +265,3 @@ for $c-data<cases>.values -> $case {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/all-your-base/example.yaml
+++ b/exercises/all-your-base/example.yaml
@@ -1,7 +1,6 @@
 exercise: AllYourBase
-version: 3
-plan: 23
-imports: '&convert-base'
+version: 4
+plan: 21
 tests: |-
   for $c-data<cases>.values -> $case {
     sub call-convert-base {

--- a/exercises/allergies/Allergies.pm6
+++ b/exercises/allergies/Allergies.pm6
@@ -1,1 +1,1 @@
-unit module Allergies:ver<3>;
+unit module Allergies:ver<4>;

--- a/exercises/allergies/Example.pm6
+++ b/exercises/allergies/Example.pm6
@@ -1,4 +1,4 @@
-unit module Allergies:ver<3>;
+unit module Allergies:ver<4>;
 
 our @allergens = <
     eggs

--- a/exercises/allergies/allergies.t
+++ b/exercises/allergies/allergies.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Allergies;
+plan 2;
 
-my Str:D $exercise := 'Allergies';
-my Version:D $version = v3;
-my Str $module //= $exercise;
-plan 4;
+my Version:D $version = v4;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Allergies.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nAllergies is {Allergies.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&allergic-to &list-allergies>;
 
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>.values -> %case-set {
@@ -226,18 +219,3 @@ for $c-data<cases>.values -> %case-set {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/allergies/example.yaml
+++ b/exercises/allergies/example.yaml
@@ -1,7 +1,6 @@
 exercise: Allergies
-version: 3
-plan: 4
-imports: '&allergic-to &list-allergies'
+version: 4
+plan: 2
 tests: |-
   for $c-data<cases>.values -> %case-set {
 

--- a/exercises/anagram/Anagram.pm6
+++ b/exercises/anagram/Anagram.pm6
@@ -1,4 +1,4 @@
-unit module Anagram:ver<2>;
+unit module Anagram:ver<3>;
 
 sub match-anagrams (:$subject!, :@candidates!) is export {
 }

--- a/exercises/anagram/Example.pm6
+++ b/exercises/anagram/Example.pm6
@@ -1,4 +1,4 @@
-unit module Anagram:ver<2>;
+unit module Anagram:ver<3>;
 
 sub match-anagrams ( :$subject!, :@candidates! ) is export {
   given $subject.uc -> $ucs {

--- a/exercises/anagram/anagram.t
+++ b/exercises/anagram/anagram.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Anagram;
+plan 16;
 
-my Str:D $exercise := 'Anagram';
-my Version:D $version = v2;
-my Str $module //= $exercise;
-plan 18;
+my Version:D $version = v3;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Anagram.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nAnagram is {Anagram.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&match-anagrams>;
 
 my $c-data = from-json $=pod.pop.contents;
 cmp-ok match-anagrams( |%(.<input><subject candidates>:p) ), '~~', .<expected>.Set, .<description> for $c-data<cases>.values;
@@ -192,18 +185,3 @@ cmp-ok match-anagrams( |%(.<input><subject candidates>:p) ), '~~', .<expected>.S
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/anagram/example.yaml
+++ b/exercises/anagram/example.yaml
@@ -1,7 +1,6 @@
 exercise: Anagram
-version: 2
-plan: 18
-imports: '&match-anagrams'
+version: 3
+plan: 16
 tests: |-
   cmp-ok match-anagrams( |%(.<input><subject candidates>:p) ), '~~', .<expected>.Set, .<description> for $c-data<cases>.values;
 

--- a/exercises/atbash-cipher/AtbashCipher.pm6
+++ b/exercises/atbash-cipher/AtbashCipher.pm6
@@ -1,4 +1,4 @@
-unit module AtbashCipher:ver<1>;
+unit module AtbashCipher:ver<2>;
 
 sub encode ($phrase) is export {
 }

--- a/exercises/atbash-cipher/Example.pm6
+++ b/exercises/atbash-cipher/Example.pm6
@@ -1,4 +1,4 @@
-unit module AtbashCipher:ver<1>;
+unit module AtbashCipher:ver<2>;
 
 sub encode($input) is export {
     decode($input.lc.trans( ['a'..'z', 0..9] => '', :complement ) )

--- a/exercises/atbash-cipher/atbash-cipher.t
+++ b/exercises/atbash-cipher/atbash-cipher.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use AtbashCipher;
+plan 12;
 
-my Str:D $exercise := 'AtbashCipher';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 14;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if AtbashCipher.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nAtbashCipher is {AtbashCipher.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&encode &decode>;
 
 my $c-data = from-json $=pod.pop.contents;
 is .<input><phrase>.&::(.<property>), |.<expected description> for $c-data<cases>»<cases>».Array.flat;
@@ -147,18 +140,3 @@ is .<input><phrase>.&::(.<property>), |.<expected description> for $c-data<cases
   ]
 }
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/atbash-cipher/example.yaml
+++ b/exercises/atbash-cipher/example.yaml
@@ -1,7 +1,6 @@
 exercise: AtbashCipher
-version: 1
-plan: 14
-imports: '&encode &decode'
+version: 2
+plan: 12
 tests: |-
   is .<input><phrase>.&::(.<property>), |.<expected description> for $c-data<cases>»<cases>».Array.flat;
 

--- a/exercises/binary/binary.t
+++ b/exercises/binary/binary.t
@@ -1,12 +1,10 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib IO::Path.new($?FILE).parent.path;
+use lib $?FILE.IO.dirname;
+use Binary;
 
-plan 10;
-my $module = %*ENV<EXERCISM> ?? 'Example' !! 'Binary';
-use-ok $module;
-require ::($module) <Binary>;
+plan 9;
 
 ok Binary.can('to_decimal'), 'Class Binary has to_decimal method';
 

--- a/exercises/bob/Bob.pm6
+++ b/exercises/bob/Bob.pm6
@@ -2,7 +2,7 @@
   Declare class 'Bob' with version and unit-scope the class
   i.e. everything in this file is part of 'Bob'.
 ]
-unit class Bob:ver<2>;
+unit class Bob:ver<3>;
 
 method hey ($msg) {
   #`[

--- a/exercises/bob/Example.pm6
+++ b/exercises/bob/Example.pm6
@@ -2,7 +2,7 @@
   Declare class 'Bob' with version and unit-scope the class
   i.e. everything in this file is part of 'Bob'.
 ]
-unit class Bob:ver<2>;
+unit class Bob:ver<3>;
 
 method hey ( Str:D $_ --> Str:D ) {
   my \shouting = /<:L>/ ^ /<:Ll>/;

--- a/exercises/bob/bob.t
+++ b/exercises/bob/bob.t
@@ -1,36 +1,30 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname; #`[Look for the module inside the same directory as this test file.]
 use JSON::Fast;
+use lib $?FILE.IO.dirname; #`[Look for the module inside the same directory as this test file.]
+use Bob;
+plan 26; #`[This is how many tests we expect to run.]
 
-my Str:D $exercise := 'Bob'; #`[The name of this exercise.]
-my Version:D $version = v2; #`[The version we will be matching against the exercise.]
-my Str $module //= $exercise; #`[The name of the module file to be loaded.]
-plan 28; #`[This is how many tests we expect to run.]
-
-#`[Check that the module can be use-d.]
-use-ok $module or bail-out;
-require ::($module);
+my Version:D $version = v3; #`[The version we will be matching against the exercise.]
 
 #`[If the exercise is updated, we want to make sure other people testing
 your code don't think you've made a mistake if things have changed!]
-if ::($exercise).^ver !~~ $version {
+if Bob.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nBob is {Bob.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
 
 #`[Check that the class 'Bob' can use all of the methods
 needed in the tests (only 'hey' for this one).]
 subtest 'Class methods', {
-  ok ::($exercise).can($_), $_ for <hey>;
+  ok Bob.can($_), $_ for <hey>;
 }
 
 my $c-data = from-json $=pod.pop.contents;
 # Go through the cases and check that Bob gives us the correct responses.
-is ::($exercise).?hey(.<input><heyBob>), |.<expected description> for @($c-data<cases>);
+is Bob.?hey(.<input><heyBob>), |.<expected description> for @($c-data<cases>);
 
 =head2 Canonical Data
 =begin code
@@ -243,20 +237,3 @@ is ::($exercise).?hey(.<input><heyBob>), |.<expected description> for @($c-data<
 }
 
 =end code
-
-#`[Don't worry about the stuff below here for your exercise.
-This is for Exercism folks to check that everything is in order.]
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/bob/example.yaml
+++ b/exercises/bob/example.yaml
@@ -1,20 +1,16 @@
 exercise: Bob
-version: 2
-plan: 28
+version: 3
+plan: 26
 methods: hey
 tests: |-
   # Go through the cases and check that Bob gives us the correct responses.
-  is ::($exercise).?hey(.<input><heyBob>), |.<expected description> for @($c-data<cases>);
+  is Bob.?hey(.<input><heyBob>), |.<expected description> for @($c-data<cases>);
 
-exercise_comment: The name of this exercise.
-module_comment: The name of the module file to be loaded.
 version_comment: The version we will be matching against the exercise.
 lib_comment: Look for the module inside the same directory as this test file.
 plan_comment: This is how many tests we expect to run.
-use_test_comment: Check that the module can be use-d.
 version_test_comment: "If the exercise is updated, we want to make sure other people testing\nyour code don't think you've made a mistake if things have changed!"
 methods_comment: "Check that the class 'Bob' can use all of the methods\nneeded in the tests (only 'hey' for this one)."
-exercism_comment: "Don't worry about the stuff below here for your exercise.\nThis is for Exercism folks to check that everything is in order."
 
 unit: class
 unit_comment: |-

--- a/exercises/clock/Clock.pm6
+++ b/exercises/clock/Clock.pm6
@@ -1,4 +1,4 @@
-unit class Clock:ver<1>;
+unit class Clock:ver<2>;
 
 has $.hour;
 has $.minute;

--- a/exercises/clock/Example.pm6
+++ b/exercises/clock/Example.pm6
@@ -1,4 +1,4 @@
-unit class Clock:ver<1>;
+unit class Clock:ver<2>;
 
 has Int:D $.hour = 0;
 has Int:D $.minute = 0;

--- a/exercises/clock/clock.t
+++ b/exercises/clock/clock.t
@@ -1,44 +1,39 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Clock;
+plan 52;
 
-my Str:D $exercise := 'Clock';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 54;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Clock.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nClock is {Clock.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
 
 subtest 'Class methods', {
-  ok ::($exercise).can($_), $_ for <time add-minutes>;
+  ok Clock.can($_), $_ for <time add-minutes>;
 }
 
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>»<cases>».Array.flat -> %case {
   given %case<property> {
     when 'create' {
-      is ::($exercise).?new( |%(.<hour minute>:p) ).?time, |.<expected description> given %case;
+      is Clock.?new( |%(.<hour minute>:p) ).?time, |.<expected description> given %case;
     }
     when 'add' {
       given %case {
-        my $clock = ::($exercise).?new: |%(.<hour minute>:p);
+        my $clock = Clock.?new: |%(.<hour minute>:p);
         $clock.?add-minutes: .<add>;
         is $clock.?time, |.<expected description>;
       }
     }
     when 'equal' {
       is-deeply ([eq] gather {
-        take ::($exercise).?new( |%(.<hour minute>:p) ).?time for %case<clock1 clock2>;
+        take Clock.?new( |%(.<hour minute>:p) ).?time for %case<clock1 clock2>;
       }), |%case<expected description>;
     }
     when %*ENV<EXERCISM>.so { bail-out "no case for property '%case<property>'" }
@@ -46,7 +41,7 @@ for $c-data<cases>»<cases>».Array.flat -> %case {
 }
 
 todo 'optional test' unless %*ENV<EXERCISM>;
-is ::($exercise).?new(:0hour,:0minute).?add-minutes(65).?time, '01:05', 'add-minutes method can be chained';
+is Clock.?new(:0hour,:0minute).?add-minutes(65).?time, '01:05', 'add-minutes method can be chained';
 
 =head2 Canonical Data
 =begin code
@@ -542,18 +537,3 @@ is ::($exercise).?new(:0hour,:0minute).?add-minutes(65).?time, '01:05', 'add-min
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/clock/example.yaml
+++ b/exercises/clock/example.yaml
@@ -1,23 +1,23 @@
 exercise: Clock
-version: 1
+version: 2
 methods: time add-minutes
-plan: 54
+plan: 52
 tests: |-
   for $c-data<cases>»<cases>».Array.flat -> %case {
     given %case<property> {
       when 'create' {
-        is ::($exercise).?new( |%(.<hour minute>:p) ).?time, |.<expected description> given %case;
+        is Clock.?new( |%(.<hour minute>:p) ).?time, |.<expected description> given %case;
       }
       when 'add' {
         given %case {
-          my $clock = ::($exercise).?new: |%(.<hour minute>:p);
+          my $clock = Clock.?new: |%(.<hour minute>:p);
           $clock.?add-minutes: .<add>;
           is $clock.?time, |.<expected description>;
         }
       }
       when 'equal' {
         is-deeply ([eq] gather {
-          take ::($exercise).?new( |%(.<hour minute>:p) ).?time for %case<clock1 clock2>;
+          take Clock.?new( |%(.<hour minute>:p) ).?time for %case<clock1 clock2>;
         }), |%case<expected description>;
       }
       when %*ENV<EXERCISM>.so { bail-out "no case for property '%case<property>'" }
@@ -25,7 +25,7 @@ tests: |-
   }
 
   todo 'optional test' unless %*ENV<EXERCISM>;
-  is ::($exercise).?new(:0hour,:0minute).?add-minutes(65).?time, '01:05', 'add-minutes method can be chained';
+  is Clock.?new(:0hour,:0minute).?add-minutes(65).?time, '01:05', 'add-minutes method can be chained';
 
 unit: class
 example: |-

--- a/exercises/etl/ETL.pm6
+++ b/exercises/etl/ETL.pm6
@@ -1,4 +1,4 @@
-unit module ETL:ver<1>;
+unit module ETL:ver<2>;
 
 no precompilation;
 

--- a/exercises/etl/Example.pm6
+++ b/exercises/etl/Example.pm6
@@ -1,4 +1,4 @@
-unit module ETL:ver<1>;
+unit module ETL:ver<2>;
 
 no precompilation;
 

--- a/exercises/etl/etl.t
+++ b/exercises/etl/etl.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use ETL;
+plan 4;
 
-my Str:D $exercise := 'ETL';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 6;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if ETL.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nETL is {ETL.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&transform>;
 
 my $c-data = from-json $=pod.pop.contents;
 =head2 Notes
@@ -122,18 +115,3 @@ for $c-data<cases>.values -> %case-set {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/etl/example.yaml
+++ b/exercises/etl/example.yaml
@@ -1,7 +1,6 @@
 exercise: ETL
-version: 1
-plan: 6
-imports: '&transform'
+version: 2
+plan: 4
 tests: |-
   =head2 Notes
   =begin para

--- a/exercises/flatten-array/Example.pm6
+++ b/exercises/flatten-array/Example.pm6
@@ -1,4 +1,4 @@
-unit module FlattenArray:ver<1>;
+unit module FlattenArray:ver<2>;
 
 sub flatten-array(@input --> Array) is export {
   @input.&denest;

--- a/exercises/flatten-array/FlattenArray.pm6
+++ b/exercises/flatten-array/FlattenArray.pm6
@@ -1,4 +1,4 @@
-unit module FlattenArray:ver<1>;
+unit module FlattenArray:ver<2>;
 
 sub flatten-array(@input) is export {
 }

--- a/exercises/flatten-array/example.yaml
+++ b/exercises/flatten-array/example.yaml
@@ -1,7 +1,6 @@
 exercise: FlattenArray
-version: 1
-plan: 8
-imports: '&flatten-array'
+version: 2
+plan: 6
 tests: |-
   is-deeply flatten-array(.<input><array>), |.<expected description> for @($c-data<cases>);
 

--- a/exercises/flatten-array/flatten-array.t
+++ b/exercises/flatten-array/flatten-array.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use FlattenArray;
+plan 6;
 
-my Str:D $exercise := 'FlattenArray';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 8;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if FlattenArray.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nFlattenArray is {FlattenArray.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&flatten-array>;
 
 my $c-data = from-json $=pod.pop.contents;
 is-deeply flatten-array(.<input><array>), |.<expected description> for @($c-data<cases>);
@@ -83,18 +76,3 @@ is-deeply flatten-array(.<input><array>), |.<expected description> for @($c-data
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/grade-school/Example.pm6
+++ b/exercises/grade-school/Example.pm6
@@ -1,4 +1,4 @@
-unit module GradeSchool:ver<2>;
+unit module GradeSchool:ver<3>;
 
 class Roster is export {
   has %!roster;

--- a/exercises/grade-school/GradeSchool.pm6
+++ b/exercises/grade-school/GradeSchool.pm6
@@ -1,4 +1,4 @@
-unit module GradeSchool:ver<2>;
+unit module GradeSchool:ver<3>;
 
 class Roster is export {
 }

--- a/exercises/grade-school/example.yaml
+++ b/exercises/grade-school/example.yaml
@@ -1,7 +1,6 @@
 exercise: GradeSchool
-version: 2
-plan: 19
-imports: Roster
+version: 3
+plan: 18
 tests: |-
   subtest "Roster class methods", {
     plan 3;

--- a/exercises/grade-school/grade-school.t
+++ b/exercises/grade-school/grade-school.t
@@ -2,23 +2,16 @@
 use v6;
 use Test;
 use lib $?FILE.IO.dirname;
+use GradeSchool;
+plan 18;
 
-my Str:D $exercise := 'GradeSchool';
-my Version:D $version = v2;
-my Str $module //= $exercise;
-plan 19;
+my Version:D $version = v3;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if GradeSchool.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nGradeSchool is {GradeSchool.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <Roster>;
 
 subtest "Roster class methods", {
   plan 3;
@@ -45,5 +38,3 @@ cmp-ok $roster.?list-grade(1), '~~', <Anna Barb Charlie>, 'List grade 1';
 cmp-ok $roster.?list-grade(2), '~~', <Alex Jim Zoe>, 'List grade 2';
 cmp-ok $roster.?list-grade(3), '~~', <Dick Harry Tom>, 'List grade 3';
 cmp-ok $roster.?list-all, '~~', ('Grade 1', <Anna Barb Charlie>, 'Grade 2', <Alex Jim Zoe>, 'Grade 3', <Dick Harry Tom>), 'List all';
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/grains/Example.pm6
+++ b/exercises/grains/Example.pm6
@@ -1,4 +1,4 @@
-unit module Grains:ver<1>;
+unit module Grains:ver<2>;
 
 sub grains-on-square ($number) is export {
   die if $number < 1 or $number > 64;

--- a/exercises/grains/Grains.pm6
+++ b/exercises/grains/Grains.pm6
@@ -1,1 +1,1 @@
-unit module Grains:ver<1>;
+unit module Grains:ver<2>;

--- a/exercises/grains/example.yaml
+++ b/exercises/grains/example.yaml
@@ -1,7 +1,6 @@
 exercise: Grains
-version: 1
-plan: 13
-imports: '&grains-on-square &total-grains'
+version: 2
+plan: 11
 tests: |-
   for @($c-data<cases>[0]<cases>) {
     if .<expected> == -1 {

--- a/exercises/grains/grains.t
+++ b/exercises/grains/grains.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Grains;
+plan 11;
 
-my Str:D $exercise := 'Grains';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 13;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Grains.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nGrains is {Grains.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&grains-on-square &total-grains>;
 
 my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>[0]<cases>) {
@@ -117,18 +110,3 @@ is total-grains, |$c-data<cases>[1]<expected description>;
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/hamming/Example.pm6
+++ b/exercises/hamming/Example.pm6
@@ -1,4 +1,4 @@
-unit module Hamming:ver<2>;
+unit module Hamming:ver<3>;
 
 sub hamming-distance (
   +@strands where { .elems == 2 && [==] $_».chars } --> Int:D

--- a/exercises/hamming/Hamming.pm6
+++ b/exercises/hamming/Hamming.pm6
@@ -1,4 +1,4 @@
-unit module Hamming:ver<2>;
+unit module Hamming:ver<3>;
 
 sub hamming-distance ($strand1, $strand2) is export {
 }

--- a/exercises/hamming/example.yaml
+++ b/exercises/hamming/example.yaml
@@ -1,7 +1,6 @@
 exercise: Hamming
-version: 2
-plan: 17
-imports: '&hamming-distance'
+version: 3
+plan: 15
 tests: |-
   for $c-data<cases>.values {
     if .<expected><error> {

--- a/exercises/hamming/hamming.t
+++ b/exercises/hamming/hamming.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Hamming;
+plan 15;
 
-my Str:D $exercise := 'Hamming';
-my Version:D $version = v2;
-my Str $module //= $exercise;
-plan 17;
+my Version:D $version = v3;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Hamming.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nHamming is {Hamming.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&hamming-distance>;
 
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>.values {
@@ -158,18 +151,3 @@ for $c-data<cases>.values {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/hello-world/Example.pm6
+++ b/exercises/hello-world/Example.pm6
@@ -7,7 +7,7 @@
   and test suite line up. If the test is updated, it will indicate
   to others who test your code that some tests may no longer pass.
 )
-unit module HelloWorld:ver<2>;
+unit module HelloWorld:ver<3>;
 
 sub hello is export {
   'Hello, World!'

--- a/exercises/hello-world/HelloWorld.pm6
+++ b/exercises/hello-world/HelloWorld.pm6
@@ -7,7 +7,7 @@
   and test suite line up. If the test is updated, it will indicate
   to others who test your code that some tests may no longer pass.
 )
-unit module HelloWorld:ver<2>;
+unit module HelloWorld:ver<3>;
 
 sub hello is export {
   # Write your solution to pass the test suite here.

--- a/exercises/hello-world/example.yaml
+++ b/exercises/hello-world/example.yaml
@@ -1,20 +1,14 @@
 exercise: HelloWorld
-version: 2
-plan: 3
-imports: '&hello'
+version: 3
+plan: 1
 tests: |-
   # Go through the cases and check that &hello gives us the correct response.
   is hello, |.<expected description> for @($c-data<cases>);
 
-exercise_comment: The name of this exercise.
-module_comment: The name of the module file to be loaded.
 version_comment: The version we will be matching against the exercise.
 lib_comment: Look for the module inside the same directory as this test file.
 plan_comment: This is how many tests we expect to run.
-use_test_comment: Check that the module can be use-d.
 version_test_comment: "If the exercise is updated, we want to make sure other people testing\nyour code don't think you've made a mistake if things have changed!"
-imports_comment: Import '&hello' from 'HelloWorld'
-exercism_comment: "Don't worry about the stuff below here for your exercise.\nThis is for Exercism folks to check that everything is in order."
 
 unit: module
 unit_comment: |-

--- a/exercises/hello-world/hello-world.t
+++ b/exercises/hello-world/hello-world.t
@@ -1,29 +1,20 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname; #`[Look for the module inside the same directory as this test file.]
 use JSON::Fast;
+use lib $?FILE.IO.dirname; #`[Look for the module inside the same directory as this test file.]
+use HelloWorld;
+plan 1; #`[This is how many tests we expect to run.]
 
-my Str:D $exercise := 'HelloWorld'; #`[The name of this exercise.]
-my Version:D $version = v2; #`[The version we will be matching against the exercise.]
-my Str $module //= $exercise; #`[The name of the module file to be loaded.]
-plan 3; #`[This is how many tests we expect to run.]
-
-#`[Check that the module can be use-d.]
-use-ok $module or bail-out;
-require ::($module);
+my Version:D $version = v3; #`[The version we will be matching against the exercise.]
 
 #`[If the exercise is updated, we want to make sure other people testing
 your code don't think you've made a mistake if things have changed!]
-if ::($exercise).^ver !~~ $version {
+if HelloWorld.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nHelloWorld is {HelloWorld.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-#`[Import '&hello' from 'HelloWorld']
-require ::($module) <&hello>;
 
 my $c-data = from-json $=pod.pop.contents;
 # Go through the cases and check that &hello gives us the correct response.
@@ -45,20 +36,3 @@ is hello, |.<expected description> for @($c-data<cases>);
 }
 
 =end code
-
-#`[Don't worry about the stuff below here for your exercise.
-This is for Exercism folks to check that everything is in order.]
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/leap/Example.pm6
+++ b/exercises/leap/Example.pm6
@@ -1,4 +1,4 @@
-unit module Leap:ver<3>;
+unit module Leap:ver<4>;
 
 sub is-leap-year ($year) is export {
   is-divisible($year, 400)

--- a/exercises/leap/Leap.pm6
+++ b/exercises/leap/Leap.pm6
@@ -1,4 +1,4 @@
-unit module Leap:ver<3>;
+unit module Leap:ver<4>;
 
 sub is-leap-year ($year) is export {
 }

--- a/exercises/leap/example.yaml
+++ b/exercises/leap/example.yaml
@@ -1,7 +1,6 @@
 exercise: Leap
-version: 3
-plan: 6
-imports: '&is-leap-year'
+version: 4
+plan: 4
 tests: |-
   for $c-data<cases>.values {
     given is-leap-year .<input> -> $result {

--- a/exercises/leap/leap.t
+++ b/exercises/leap/leap.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Leap;
+plan 4;
 
-my Str:D $exercise := 'Leap';
-my Version:D $version = v3;
-my Str $module //= $exercise;
-plan 6;
+my Version:D $version = v4;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Leap.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nLeap is {Leap.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&is-leap-year>;
 
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>.values {
@@ -67,18 +60,3 @@ for $c-data<cases>.values {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/linked-list/Example.pm6
+++ b/exercises/linked-list/Example.pm6
@@ -1,4 +1,4 @@
-unit class LinkedList:ver<1>;
+unit class LinkedList:ver<2>;
 
 class ListNode {
     has $.next     is rw;

--- a/exercises/linked-list/LinkedList.pm6
+++ b/exercises/linked-list/LinkedList.pm6
@@ -1,1 +1,1 @@
-unit class LinkedList:ver<1>;
+unit class LinkedList:ver<2>;

--- a/exercises/linked-list/example.yaml
+++ b/exercises/linked-list/example.yaml
@@ -1,6 +1,6 @@
 exercise: LinkedList
-version: 1
-plan: 7
+version: 2
+plan: 6
 modules:
   - use: JSON::Fast
 methods: 'push-list pop-list shift-list unshift-list'
@@ -8,7 +8,7 @@ tests: |-
   my $cases = from-json $=pod.pop.contents;
   for $cases.values -> $case {
     subtest $case.<name>, sub {
-      my $linkedlist = ::($exercise).new;
+      my $linkedlist = LinkedList.new;
       for  |$case.<set> -> %set {
         for %set {
           my $value = $_.value;

--- a/exercises/linked-list/linked-list.t
+++ b/exercises/linked-list/linked-list.t
@@ -1,32 +1,27 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use LinkedList;
+plan 6;
 
-my Str:D $exercise := 'LinkedList';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 7;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if LinkedList.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nLinkedList is {LinkedList.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
 
 subtest 'Class methods', {
-  ok ::($exercise).can($_), $_ for <push-list pop-list shift-list unshift-list>;
+  ok LinkedList.can($_), $_ for <push-list pop-list shift-list unshift-list>;
 }
 
 my $cases = from-json $=pod.pop.contents;
 for $cases.values -> $case {
   subtest $case.<name>, sub {
-    my $linkedlist = ::($exercise).new;
+    my $linkedlist = LinkedList.new;
     for  |$case.<set> -> %set {
       for %set {
         my $value = $_.value;
@@ -97,5 +92,3 @@ for $cases.values -> $case {
   }
 ]
 =end code
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/luhn/Example.pm6
+++ b/exercises/luhn/Example.pm6
@@ -1,4 +1,4 @@
-unit module Luhn:ver<2>;
+unit module Luhn:ver<3>;
 
 sub is-luhn-valid ($input is copy) is export {
   $input ~~ s:g/\s+//;

--- a/exercises/luhn/Luhn.pm6
+++ b/exercises/luhn/Luhn.pm6
@@ -1,4 +1,4 @@
-unit module Luhn:ver<2>;
+unit module Luhn:ver<3>;
 
 sub is-luhn-valid ($input) is export {
 }

--- a/exercises/luhn/example.yaml
+++ b/exercises/luhn/example.yaml
@@ -1,7 +1,6 @@
 exercise: Luhn
-version: 2
-plan: 15
-imports: '&is-luhn-valid'
+version: 3
+plan: 13
 tests: |-
   for $c-data<cases>.values {
     given is-luhn-valid .<input><value> -> $result {

--- a/exercises/luhn/luhn.t
+++ b/exercises/luhn/luhn.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Luhn;
+plan 13;
 
-my Str:D $exercise := 'Luhn';
-my Version:D $version = v2;
-my Str $module //= $exercise;
-plan 15;
+my Version:D $version = v3;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Luhn.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nLuhn is {Luhn.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&is-luhn-valid>;
 
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>.values {
@@ -147,18 +140,3 @@ for $c-data<cases>.values {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/meetup/Example.pm6
+++ b/exercises/meetup/Example.pm6
@@ -1,4 +1,4 @@
-unit module Meetup:ver<1>;
+unit module Meetup:ver<2>;
 
 sub meetup-date (Str:D $desc --> Date:D) is export {
   my (Date $date, Str $day-of-week);

--- a/exercises/meetup/Meetup.pm6
+++ b/exercises/meetup/Meetup.pm6
@@ -1,4 +1,4 @@
-unit module Meetup:ver<1>;
+unit module Meetup:ver<2>;
 
 sub meetup-date ($desc) is export {
 }

--- a/exercises/meetup/example.yaml
+++ b/exercises/meetup/example.yaml
@@ -1,7 +1,6 @@
 exercise: Meetup
-version: 1
-plan: 97
-imports: '&meetup-date'
+version: 2
+plan: 95
 tests: |-
   is meetup-date(.<description>), Date.new(|.<year month dayofmonth>), .<description> for @($c-data<cases>);
 

--- a/exercises/meetup/meetup.t
+++ b/exercises/meetup/meetup.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Meetup;
+plan 95;
 
-my Str:D $exercise := 'Meetup';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 97;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Meetup.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nMeetup is {Meetup.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&meetup-date>;
 
 my $c-data = from-json $=pod.pop.contents;
 is meetup-date(.<description>), Date.new(|.<year month dayofmonth>), .<description> for @($c-data<cases>);
@@ -890,18 +883,3 @@ is meetup-date(.<description>), Date.new(|.<year month dayofmonth>), .<descripti
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/nucleotide-count/Example.pm6
+++ b/exercises/nucleotide-count/Example.pm6
@@ -1,4 +1,4 @@
-unit module NucleotideCount:ver<1>;
+unit module NucleotideCount:ver<2>;
 
 sub nucleotide-count (
   Str:D $_ where { .comb.Set ⊆ <A C G T> } --> Bag(Iterable:D)

--- a/exercises/nucleotide-count/NucleotideCount.pm6
+++ b/exercises/nucleotide-count/NucleotideCount.pm6
@@ -1,4 +1,4 @@
-unit module NucleotideCount:ver<1>;
+unit module NucleotideCount:ver<2>;
 
 sub nucleotide-count ($strand) is export {
 }

--- a/exercises/nucleotide-count/example.yaml
+++ b/exercises/nucleotide-count/example.yaml
@@ -1,7 +1,6 @@
 exercise: NucleotideCount
-version: 1
-plan: 7
-imports: '&nucleotide-count'
+version: 2
+plan: 5
 tests: |-
   for $c-data<cases>».<cases>».Array.flat {
     if .<expected><error> {

--- a/exercises/nucleotide-count/nucleotide-count.t
+++ b/exercises/nucleotide-count/nucleotide-count.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use NucleotideCount;
+plan 5;
 
-my Str:D $exercise := 'NucleotideCount';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 7;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if NucleotideCount.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nNucleotideCount is {NucleotideCount.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&nucleotide-count>;
 
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>».<cases>».Array.flat {
@@ -99,18 +92,3 @@ for $c-data<cases>».<cases>».Array.flat {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/pangram/Example.pm6
+++ b/exercises/pangram/Example.pm6
@@ -1,4 +1,4 @@
-unit module Pangram:ver<2>;
+unit module Pangram:ver<3>;
 
 sub is-pangram (Str:D $string --> Bool:D) is export {
   $string.lc.comb ⊇ ‘a’..‘z’

--- a/exercises/pangram/Pangram.pm6
+++ b/exercises/pangram/Pangram.pm6
@@ -1,4 +1,4 @@
-unit module Pangram:ver<2>;
+unit module Pangram:ver<3>;
 
 sub is-pangram ($string) is export {
 }

--- a/exercises/pangram/example.yaml
+++ b/exercises/pangram/example.yaml
@@ -1,7 +1,6 @@
 exercise: Pangram
-version: 2
-plan: 12
-imports: '&is-pangram'
+version: 3
+plan: 10
 tests: |-
   for $c-data<cases>».<cases>».Array.flat {
     given is-pangram .<input> -> $result {

--- a/exercises/pangram/pangram.t
+++ b/exercises/pangram/pangram.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Pangram;
+plan 10;
 
-my Str:D $exercise := 'Pangram';
-my Version:D $version = v2;
-my Str $module //= $exercise;
-plan 12;
+my Version:D $version = v3;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Pangram.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nPangram is {Pangram.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&is-pangram>;
 
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>».<cases>».Array.flat {
@@ -114,18 +107,3 @@ for $c-data<cases>».<cases>».Array.flat {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/phone-number/Example.pm6
+++ b/exercises/phone-number/Example.pm6
@@ -1,4 +1,4 @@
-unit module Phone:ver<3>;
+unit module Phone:ver<4>;
 
 sub clean-number ($number is copy) is export {
   $number ~~ s:g/<:!Nd>//;

--- a/exercises/phone-number/Phone.pm6
+++ b/exercises/phone-number/Phone.pm6
@@ -1,4 +1,4 @@
-unit module Phone:ver<3>;
+unit module Phone:ver<4>;
 
 sub clean-number ($number) is export {
 }

--- a/exercises/phone-number/example.yaml
+++ b/exercises/phone-number/example.yaml
@@ -1,7 +1,6 @@
 exercise: Phone
-version: 3
-plan: 14
-imports: '&clean-number'
+version: 4
+plan: 12
 tests: |-
   for @($c-data<cases>[0]<cases>) {
     if .<expected> {

--- a/exercises/phone-number/phone-number.t
+++ b/exercises/phone-number/phone-number.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Phone;
+plan 12;
 
-my Str:D $exercise := 'Phone';
-my Version:D $version = v3;
-my Str $module //= $exercise;
-plan 14;
+my Version:D $version = v4;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Phone.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nPhone is {Phone.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&clean-number>;
 
 my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>[0]<cases>) {
@@ -123,18 +116,3 @@ for @($c-data<cases>[0]<cases>) {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/raindrops/Example.pm6
+++ b/exercises/raindrops/Example.pm6
@@ -1,4 +1,4 @@
-unit module Raindrops:ver<1>;
+unit module Raindrops:ver<2>;
 
 sub convert (Int:D $num --> Str:D) is export {
   my $str = '';

--- a/exercises/raindrops/Raindrops.pm6
+++ b/exercises/raindrops/Raindrops.pm6
@@ -1,4 +1,4 @@
-unit module Raindrops:ver<1>;
+unit module Raindrops:ver<2>;
 
 sub convert ($num) is export {
 }

--- a/exercises/raindrops/example.yaml
+++ b/exercises/raindrops/example.yaml
@@ -1,7 +1,6 @@
 exercise: Raindrops
-version: 1
-plan: 20
-imports: '&convert'
+version: 2
+plan: 18
 tests: |-
   for @($c-data<cases>) {
     subtest {

--- a/exercises/raindrops/raindrops.t
+++ b/exercises/raindrops/raindrops.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Raindrops;
+plan 18;
 
-my Str:D $exercise := 'Raindrops';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 20;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Raindrops.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nRaindrops is {Raindrops.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&convert>;
 
 my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>) {
@@ -149,18 +142,3 @@ for @($c-data<cases>) {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/rna-transcription/Example.pm6
+++ b/exercises/rna-transcription/Example.pm6
@@ -1,4 +1,4 @@
-unit module RNA:ver<2>;
+unit module RNA:ver<3>;
 
 sub to-rna ($dna) is export {
   $dna.trans(<A G C T> => <U C G A>);

--- a/exercises/rna-transcription/RNA.pm6
+++ b/exercises/rna-transcription/RNA.pm6
@@ -1,4 +1,4 @@
-unit module RNA:ver<2>;
+unit module RNA:ver<3>;
 
 sub to-rna ($dna) is export {
 }

--- a/exercises/rna-transcription/example.yaml
+++ b/exercises/rna-transcription/example.yaml
@@ -1,7 +1,6 @@
 exercise: RNA
-version: 2
-plan: 7
-imports: '&to-rna'
+version: 3
+plan: 5
 tests: |-
   is .<dna>.&to-rna, |.<expected description> for $c-data<cases>.values;
 

--- a/exercises/rna-transcription/rna-transcription.t
+++ b/exercises/rna-transcription/rna-transcription.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use RNA;
+plan 5;
 
-my Str:D $exercise := 'RNA';
-my Version:D $version = v2;
-my Str $module //= $exercise;
-plan 7;
+my Version:D $version = v3;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if RNA.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nRNA is {RNA.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&to-rna>;
 
 my $c-data = from-json $=pod.pop.contents;
 is .<dna>.&to-rna, |.<expected description> for $c-data<cases>.values;
@@ -65,18 +58,3 @@ is .<dna>.&to-rna, |.<expected description> for $c-data<cases>.values;
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/robot-name/Example.pm6
+++ b/exercises/robot-name/Example.pm6
@@ -1,4 +1,4 @@
-unit class Robot:ver<1>;
+unit class Robot:ver<2>;
 
 subset Name of Str where * ~~ /^<[A..Z]>**2 <[0..9]>**3$/;
 has Name $.name = self.reset-name;

--- a/exercises/robot-name/Robot.pm6
+++ b/exercises/robot-name/Robot.pm6
@@ -1,1 +1,1 @@
-unit class Robot:ver<1>;
+unit class Robot:ver<2>;

--- a/exercises/robot-name/example.yaml
+++ b/exercises/robot-name/example.yaml
@@ -1,17 +1,17 @@
 exercise: Robot
-version: 1
+version: 2
 methods: name reset-name
-plan: 8
+plan: 7
 tests: |-
   srand 1;
-  my $robot = ::($exercise).?new;
+  my $robot = Robot.?new;
   my Str $name = $robot.?name;
   like $name, /^^<[A..Z]>**2 <[0..9]>**3$$/, 'Name matches schema';
 
   srand 2;
   is $robot.?name, $name, 'Name is persistent';
   srand 1;
-  isnt ::($exercise).new.?name, $name, 'New Robot cannot claim previous Robot name';
+  isnt Robot.new.?name, $name, 'New Robot cannot claim previous Robot name';
 
   srand 1;
   $robot.?reset-name;
@@ -20,7 +20,7 @@ tests: |-
   isnt $robot.?name, $name, "'reset-name' cannot use previous Robot name";
 
   diag "\nCreating 100 robots...";
-  push my @names, ::($exercise).new.name for 1..100;
+  push my @names, Robot.new.name for 1..100;
   is @names, @names.unique, 'All names are unique';
   subtest 'Randomness', {
     plan 2;

--- a/exercises/robot-name/robot-name.t
+++ b/exercises/robot-name/robot-name.t
@@ -2,35 +2,30 @@
 use v6;
 use Test;
 use lib $?FILE.IO.dirname;
+use Robot;
+plan 7;
 
-my Str:D $exercise := 'Robot';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 8;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Robot.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nRobot is {Robot.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
 
 subtest 'Class methods', {
-  ok ::($exercise).can($_), $_ for <name reset-name>;
+  ok Robot.can($_), $_ for <name reset-name>;
 }
 
 srand 1;
-my $robot = ::($exercise).?new;
+my $robot = Robot.?new;
 my Str $name = $robot.?name;
 like $name, /^^<[A..Z]>**2 <[0..9]>**3$$/, 'Name matches schema';
 
 srand 2;
 is $robot.?name, $name, 'Name is persistent';
 srand 1;
-isnt ::($exercise).new.?name, $name, 'New Robot cannot claim previous Robot name';
+isnt Robot.new.?name, $name, 'New Robot cannot claim previous Robot name';
 
 srand 1;
 $robot.?reset-name;
@@ -39,12 +34,10 @@ $robot.?reset_name; # Allows next test to still pass for older solutions
 isnt $robot.?name, $name, "'reset-name' cannot use previous Robot name";
 
 diag "\nCreating 100 robots...";
-push my @names, ::($exercise).new.name for 1..100;
+push my @names, Robot.new.name for 1..100;
 is @names, @names.unique, 'All names are unique';
 subtest 'Randomness', {
   plan 2;
   isnt @names, @names.sort, 'Names not ordered';
   isnt @names, @names.sort.reverse, 'Names not reverse ordered';
 }
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/roman-numerals/Example.pm6
+++ b/exercises/roman-numerals/Example.pm6
@@ -1,4 +1,4 @@
-unit module RomanNumerals:ver<1>;
+unit module RomanNumerals:ver<2>;
 
 
 my %table{Int} = <1000 900 500 400 100 90 50 40 10 9 5 4 1>

--- a/exercises/roman-numerals/RomanNumerals.pm6
+++ b/exercises/roman-numerals/RomanNumerals.pm6
@@ -1,4 +1,4 @@
-unit module RomanNumerals:ver<1>;
+unit module RomanNumerals:ver<2>;
 
 sub to-roman ($number) is export {
 }

--- a/exercises/roman-numerals/example.yaml
+++ b/exercises/roman-numerals/example.yaml
@@ -1,7 +1,6 @@
 exercise: RomanNumerals
-version: 1
-plan: 20
-imports: '&to-roman'
+version: 2
+plan: 18
 tests: |-
   for $c-data<cases>.values {
     is to-roman(.<number>), |.<expected description>;

--- a/exercises/roman-numerals/roman-numerals.t
+++ b/exercises/roman-numerals/roman-numerals.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use RomanNumerals;
+plan 18;
 
-my Str:D $exercise := 'RomanNumerals';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 20;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if RomanNumerals.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nRomanNumerals is {RomanNumerals.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&to-roman>;
 
 my $c-data = from-json $=pod.pop.contents;
 for $c-data<cases>.values {
@@ -145,18 +138,3 @@ for $c-data<cases>.values {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/scrabble-score/Example.pm6
+++ b/exercises/scrabble-score/Example.pm6
@@ -1,4 +1,4 @@
-unit module Scrabble:ver<1>;
+unit module Scrabble:ver<2>;
 
 sub score (Str:D $word --> Int:D) is export {
   my $score = 0;

--- a/exercises/scrabble-score/Scrabble.pm6
+++ b/exercises/scrabble-score/Scrabble.pm6
@@ -1,4 +1,4 @@
-unit module Scrabble:ver<1>;
+unit module Scrabble:ver<2>;
 
 sub score ($word) is export {
 }

--- a/exercises/scrabble-score/example.yaml
+++ b/exercises/scrabble-score/example.yaml
@@ -1,7 +1,6 @@
 exercise: Scrabble
-version: 1
-plan: 13
-imports: '&score'
+version: 2
+plan: 11
 tests: |-
   is .<input>.&score, |.<expected description> for @($c-data<cases>);
 

--- a/exercises/scrabble-score/scrabble-score.t
+++ b/exercises/scrabble-score/scrabble-score.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Scrabble;
+plan 11;
 
-my Str:D $exercise := 'Scrabble';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 13;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Scrabble.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nScrabble is {Scrabble.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&score>;
 
 my $c-data = from-json $=pod.pop.contents;
 is .<input>.&score, |.<expected description> for @($c-data<cases>);
@@ -101,18 +94,3 @@ is .<input>.&score, |.<expected description> for @($c-data<cases>);
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/space-age/Example.pm6
+++ b/exercises/space-age/Example.pm6
@@ -1,4 +1,4 @@
-unit module SpaceAge:ver<1>;
+unit module SpaceAge:ver<2>;
 
 role Planet {
   method age-on ($seconds) {

--- a/exercises/space-age/SpaceAge.pm6
+++ b/exercises/space-age/SpaceAge.pm6
@@ -1,4 +1,4 @@
-unit module SpaceAge:ver<1>;
+unit module SpaceAge:ver<2>;
 
 role Planet {
   method age-on ($seconds) {

--- a/exercises/space-age/example.yaml
+++ b/exercises/space-age/example.yaml
@@ -1,7 +1,6 @@
 exercise: SpaceAge
-version: 1
-plan: 10
-imports: Mercury Venus Earth Mars Jupiter Saturn Uranus Neptune
+version: 2
+plan: 8
 tests: |-
   is (age-on ::(.<planet>): .<seconds>), |.<expected description> for @($c-data<cases>);
 

--- a/exercises/space-age/space-age.t
+++ b/exercises/space-age/space-age.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use SpaceAge;
+plan 8;
 
-my Str:D $exercise := 'SpaceAge';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 10;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if SpaceAge.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nSpaceAge is {SpaceAge.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <Mercury Venus Earth Mars Jupiter Saturn Uranus Neptune>;
 
 my $c-data = from-json $=pod.pop.contents;
 is (age-on ::(.<planet>): .<seconds>), |.<expected description> for @($c-data<cases>);
@@ -91,18 +84,3 @@ is (age-on ::(.<planet>): .<seconds>), |.<expected description> for @($c-data<ca
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/trinary/trinary.t
+++ b/exercises/trinary/trinary.t
@@ -1,11 +1,8 @@
 #!/usr/bin/env perl6
 
 use Test;
-
-use lib ( my $dir = IO::Path.new($?FILE).parent ).path;
-
-my $module = %*ENV<EXERCISM> ?? 'Example' !! 'Trinary';
-require ::($module) <&to-decimal>;
+use lib $?FILE.IO.dirname;
+use Trinary;
 
 my @cases = (
     {

--- a/exercises/two-fer/Example.pm6
+++ b/exercises/two-fer/Example.pm6
@@ -7,7 +7,7 @@
   and test suite line up. If the test is updated, it will indicate
   to others who test your code that some tests may no longer pass.
 )
-unit module TwoFer:ver<1>;
+unit module TwoFer:ver<2>;
 
 sub two-fer ($name = ‘you’) is export {
   “One for $name, one for me.”

--- a/exercises/two-fer/TwoFer.pm6
+++ b/exercises/two-fer/TwoFer.pm6
@@ -7,7 +7,7 @@
   and test suite line up. If the test is updated, it will indicate
   to others who test your code that some tests may no longer pass.
 )
-unit module TwoFer:ver<1>;
+unit module TwoFer:ver<2>;
 
 sub two-fer ($name?) is export {
   # Write your solution to pass the test suite here.

--- a/exercises/two-fer/example.yaml
+++ b/exercises/two-fer/example.yaml
@@ -1,7 +1,6 @@
 exercise: TwoFer
-version: 1
-plan: 5
-imports: '&two-fer'
+version: 2
+plan: 3
 tests: |-
   # Go through the cases and check that &two-fer gives us the correct response.
   for $c-data<cases>.values {
@@ -11,15 +10,10 @@ tests: |-
       |.<expected description>;
   }
 
-exercise_comment: The name of this exercise.
-module_comment: The name of the module file to be loaded.
 version_comment: The version we will be matching against the exercise.
 lib_comment: Look for the module inside the same directory as this test file.
 plan_comment: This is how many tests we expect to run.
-use_test_comment: Check that the module can be use-d.
 version_test_comment: "If the exercise is updated, we want to make sure other people testing\nyour code don't think you've made a mistake if things have changed!"
-imports_comment: Import '&two-fer' from 'TwoFer'
-exercism_comment: "Don't worry about the stuff below here for your exercise.\nThis is for Exercism folks to check that everything is in order."
 
 unit: module
 unit_comment: |-

--- a/exercises/two-fer/two-fer.t
+++ b/exercises/two-fer/two-fer.t
@@ -1,29 +1,20 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname; #`[Look for the module inside the same directory as this test file.]
 use JSON::Fast;
+use lib $?FILE.IO.dirname; #`[Look for the module inside the same directory as this test file.]
+use TwoFer;
+plan 3; #`[This is how many tests we expect to run.]
 
-my Str:D $exercise := 'TwoFer'; #`[The name of this exercise.]
-my Version:D $version = v1; #`[The version we will be matching against the exercise.]
-my Str $module //= $exercise; #`[The name of the module file to be loaded.]
-plan 5; #`[This is how many tests we expect to run.]
-
-#`[Check that the module can be use-d.]
-use-ok $module or bail-out;
-require ::($module);
+my Version:D $version = v2; #`[The version we will be matching against the exercise.]
 
 #`[If the exercise is updated, we want to make sure other people testing
 your code don't think you've made a mistake if things have changed!]
-if ::($exercise).^ver !~~ $version {
+if TwoFer.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nTwoFer is {TwoFer.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-#`[Import '&two-fer' from 'TwoFer']
-require ::($module) <&two-fer>;
 
 my $c-data = from-json $=pod.pop.contents;
 # Go through the cases and check that &two-fer gives us the correct response.
@@ -63,20 +54,3 @@ for $c-data<cases>.values {
 }
 
 =end code
-
-#`[Don't worry about the stuff below here for your exercise.
-This is for Exercism folks to check that everything is in order.]
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/word-count/Example.pm6
+++ b/exercises/word-count/Example.pm6
@@ -1,4 +1,4 @@
-unit module WordCount:ver<2>;
+unit module WordCount:ver<3>;
 
 sub count-words (Str:D $str --> Hash:D) is export {
   $str.lc.comb(/ <alnum>+ (\'<alnum>+)? /).Bag.hash

--- a/exercises/word-count/WordCount.pm6
+++ b/exercises/word-count/WordCount.pm6
@@ -1,4 +1,4 @@
-unit module WordCount:ver<2>;
+unit module WordCount:ver<3>;
 
 sub count-words ($str) is export {
 }

--- a/exercises/word-count/example.yaml
+++ b/exercises/word-count/example.yaml
@@ -1,7 +1,6 @@
 exercise: WordCount
-version: 2
-plan: 13
-imports: '&count-words'
+version: 3
+plan: 11
 tests: |-
   is-deeply (% = .<input>.&count-words), |.<expected description> for @($c-data<cases>);
 

--- a/exercises/word-count/word-count.t
+++ b/exercises/word-count/word-count.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use WordCount;
+plan 11;
 
-my Str:D $exercise := 'WordCount';
-my Version:D $version = v2;
-my Str $module //= $exercise;
-plan 13;
+my Version:D $version = v3;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if WordCount.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nWordCount is {WordCount.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&count-words>;
 
 my $c-data = from-json $=pod.pop.contents;
 is-deeply (% = .<input>.&count-words), |.<expected description> for @($c-data<cases>);
@@ -154,18 +147,3 @@ is-deeply (% = .<input>.&count-words), |.<expected description> for @($c-data<ca
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/exercises/wordy/Example.pm6
+++ b/exercises/wordy/Example.pm6
@@ -1,4 +1,4 @@
-unit module Wordy:ver<1>;
+unit module Wordy:ver<2>;
 
 sub answer ($q is copy) is export { 
   given $q {

--- a/exercises/wordy/Wordy.pm6
+++ b/exercises/wordy/Wordy.pm6
@@ -1,4 +1,4 @@
-unit module Wordy:ver<1>;
+unit module Wordy:ver<2>;
 
 sub answer ($question) is export { 
 }

--- a/exercises/wordy/example.yaml
+++ b/exercises/wordy/example.yaml
@@ -1,7 +1,6 @@
 exercise: Wordy
-version: 1
-plan: 18
-imports: '&answer'
+version: 2
+plan: 16
 tests: |-
   for @($c-data<cases>) {
     if .<expected> === False {

--- a/exercises/wordy/wordy.t
+++ b/exercises/wordy/wordy.t
@@ -1,25 +1,18 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib my $dir = $?FILE.IO.dirname;
 use JSON::Fast;
+use lib $?FILE.IO.dirname;
+use Wordy;
+plan 16;
 
-my Str:D $exercise := 'Wordy';
-my Version:D $version = v1;
-my Str $module //= $exercise;
-plan 18;
+my Version:D $version = v2;
 
-use-ok $module or bail-out;
-require ::($module);
-
-if ::($exercise).^ver !~~ $version {
+if Wordy.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\nWordy is {Wordy.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-
-require ::($module) <&answer>;
 
 my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>) {
@@ -142,18 +135,3 @@ for @($c-data<cases>) {
 }
 
 =end code
-
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-INIT { $module = 'Example' if %*ENV<EXERCISM> }

--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -1,61 +1,32 @@
 #!/usr/bin/env perl6
 use v6;{{=#`{{ }}=}}#`{{! Mustache tags double up as Perl 6 embedded comments}}
-use Test;
-use lib #`{{#cdata}}my $dir = #`{{/cdata}}$?FILE.IO.dirname;#`{{#lib_comment}} #`[#`{{&lib_comment}}]#`{{/lib_comment}}#`{{#cdata}}
+use Test;#`{{#cdata}}
 use JSON::Fast;#`{{/cdata}}#`{{#modules}}
 use #`{{&use}};#`{{/modules}}
-
-my Str:D $exercise#`{{#exercise}} := '#`{{&exercise}}'#`{{/exercise}};#`{{#exercise_comment}} #`[#`{{&exercise_comment}}]#`{{/exercise_comment}}
-my Version:D $version#`{{#version}} = v#`{{&version}}#`{{/version}};#`{{#version_comment}} #`[#`{{&version_comment}}]#`{{/version_comment}}
-my Str $module //= $exercise;#`{{#module_comment}} #`[#`{{&module_comment}}]#`{{/module_comment}}#`{{#plan}}
+use lib $?FILE.IO.dirname;#`{{#lib_comment}} #`[#`{{&lib_comment}}]#`{{/lib_comment}}
+use #`{{&exercise}};#`{{#plan}}
 plan #`{{&plan}};#`{{#plan_comment}} #`[#`{{&plan_comment}}]#`{{/plan_comment}}#`{{/plan}}
-#`{{#use_test_comment}}
 
-#`[#`{{&use_test_comment}}]#`{{/use_test_comment}}
-use-ok $module or bail-out;
-require ::($module);
+my Version:D $version#`{{#version}} = v#`{{&version}}#`{{/version}};#`{{#version_comment}} #`[#`{{&version_comment}}]#`{{/version_comment}}
 #`{{#version_test_comment}}
 
 #`[#`{{&version_test_comment}}]#`{{/version_test_comment}}
-if ::($exercise).^ver !~~ $version {
+if #`{{&exercise}}.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
-    ~ "\n$exercise is $(::($exercise).^ver.gist). "
-    ~ "Test is $($version.gist).\n";
-  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+    ~ "\n#`{{&exercise}} is {#`{{exercise}}.^ver.gist}. "
+    ~ "Test is {$version.gist}.\n";
 }
-#`{{#imports}}#`{{#imports_comment}}
-#`[#`{{&imports_comment}}]#`{{/imports_comment}}
-require ::($module) <#`{{&imports}}>;
-#`{{/imports}}#`{{#methods}}#`{{#methods_comment}}
+#`{{#methods}}#`{{#methods_comment}}
 #`[#`{{&methods_comment}}]#`{{/methods_comment}}
 subtest 'Class methods', {
-  ok ::($exercise).can($_), $_ for <#`{{&methods}}>;
+  ok #`{{&exercise}}.can($_), $_ for <#`{{&methods}}>;
 }
 #`{{/methods}}#`{{#cdata}}
 my $c-data = from-json $=pod.pop.contents;#`{{/cdata}}
-#`{{&tests}}
-#`{{#cdata}}
+#`{{&tests}}#`{{#cdata}}
 
 =head2 Canonical Data
 =begin code
 
 #`{{&json}}
 =end code#`{{/cdata}}
-#`{{#exercism_comment}}
-
-#`[#`{{&exercism_comment}}]#`{{/exercism_comment}}#`{{#cdata}}
-unless %*ENV<EXERCISM> {
-  skip-rest 'exercism tests';
-  exit;
-}
-
-subtest 'canonical-data' => {
-  (my $c-data-file = "$dir/../../problem-specifications/exercises/{
-    $dir.IO.resolve.basename
-  }/canonical-data.json".IO.resolve) ~~ :f ??
-    is-deeply $c-data, EVAL('from-json $c-data-file.slurp'), 'match problem-specifications' !!
-    flunk 'problem-specifications file not found';
-}
-
-#`{{/cdata}}
-INIT { $module = 'Example' if %*ENV<EXERCISM> }


### PR DESCRIPTION
All of the exercism related variables/conditionals in the tests are now gone. Instead, Travis runs a script to rename `Example.pm6` files to the module the test is looking for. This results in much cleaner test suites.

Tests that checked canonical-data are gone for now, however a new test suite which will cover this will be coming in a future PR.