### PR TITLE
Add generator module and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ script:
     exercism-rakudo-star prove /exercism
     --exec perl6
     --recurse
+    --directives
     --jobs 2

--- a/lib/Exercism/Generator.pm6
+++ b/lib/Exercism/Generator.pm6
@@ -1,0 +1,37 @@
+unit class Exercism::Generator;
+use Template::Mustache;
+
+my $base-dir = $?FILE.IO.parent.add("../..");
+
+has %.data;
+has Str $.exercise;
+
+submethod TWEAK {
+  if $!exercise && (my $cdata =
+    $base-dir.add: "problem-specifications/exercises/$!exercise/canonical-data.json") ~~ :f
+  {
+    %!data<cdata><json> = $cdata.slurp;
+  }
+}
+
+method cdata {
+  %!data<cdata><json> ?? %!data<cdata><json> !! '';
+}
+
+method test {
+  self!render(template => 'test');
+}
+
+method stub {
+  self!render(template => 'module', file => 'stub');
+}
+
+method example {
+  self!render(template => 'module', file => 'example');
+}
+
+method !render (:$template!, :$file) {
+  my $data = %!data;
+  if $file { $data<module_file> = $data{$file} };
+  Template::Mustache.render($base-dir.add("templates/$template.mustache").slurp, $data);
+}

--- a/t/generated-tests.t
+++ b/t/generated-tests.t
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl6
+use v6;
+use Test;
+use YAML::Parser::LibYAML;
+use lib (my $base-dir = $?FILE.IO.resolve.parent.parent).add('lib');
+use Exercism::Generator;
+
+bail-out if $base-dir.add('problem-specifications') !~~ :d;
+for $base-dir.add('exercises').dir {
+  if .add('example.yaml') ~~ :f {
+    todo '';
+    is .add("{.basename}.t").slurp,
+      Exercism::Generator.new(data => yaml-parse(~.add: 'example.yaml'), exercise => .basename).test,
+      "{.basename}: test suite matches generated";
+  }
+}
+
+done-testing;


### PR DESCRIPTION
A new module has been created to handle the generation of exercises (the current exercise generator will be refactored to use this in a future PR).

A new test suite has also been created, and compares the existing test suites to newly generated ones. These tests are marked as `TODO`, so that they do not cause Travis to report a failed build if an exercise needs updating, but with the `--directives` flag, we still have the results of these tests logged.