### PR TITLE
raindrops: change subroutine name

### DIFF
--- a/exercises/raindrops/.meta/exercise-data.yaml
+++ b/exercises/raindrops/.meta/exercise-data.yaml
@@ -1,18 +1,18 @@
 exercise: Raindrops
-version: 2
+version: 3
 plan: 18
 tests: |-
   for @($c-data<cases>) {
     subtest {
       plan 2;
-      is .<input><number>.&convert, |.<expected description>;
-      isa-ok .<input><number>.&convert, Str;
+      is .<input><number>.&raindrop, |.<expected description>;
+      isa-ok .<input><number>.&raindrop, Str;
     }
   }
 
 unit: module
 example: |-
-  sub convert (Int:D $num --> Str:D) is export {
+  sub raindrop (Int:D $num --> Str:D) is export {
     my $str = '';
     given $num {
       when * %% 3 {$str ~= 'Pling'; proceed}
@@ -22,5 +22,5 @@ example: |-
     return $str ?? $str !! $num.Str;
   }
 stub: |-
-  sub convert ($num) is export {
+  sub raindrop ($num) is export {
   }

--- a/exercises/raindrops/.meta/solutions/Raindrops.pm6
+++ b/exercises/raindrops/.meta/solutions/Raindrops.pm6
@@ -1,6 +1,6 @@
-unit module Raindrops:ver<2>;
+unit module Raindrops:ver<3>;
 
-sub convert (Int:D $num --> Str:D) is export {
+sub raindrop (Int:D $num --> Str:D) is export {
   my $str = '';
   given $num {
     when * %% 3 {$str ~= 'Pling'; proceed}

--- a/exercises/raindrops/Raindrops.pm6
+++ b/exercises/raindrops/Raindrops.pm6
@@ -1,4 +1,4 @@
-unit module Raindrops:ver<2>;
+unit module Raindrops:ver<3>;
 
-sub convert ($num) is export {
+sub raindrop ($num) is export {
 }

--- a/exercises/raindrops/raindrops.t
+++ b/exercises/raindrops/raindrops.t
@@ -6,7 +6,7 @@ use lib $?FILE.IO.dirname;
 use Raindrops;
 plan 18;
 
-my Version:D $version = v2;
+my Version:D $version = v3;
 
 if Raindrops.^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
@@ -18,8 +18,8 @@ my $c-data = from-json $=pod.pop.contents;
 for @($c-data<cases>) {
   subtest {
     plan 2;
-    is .<input><number>.&convert, |.<expected description>;
-    isa-ok .<input><number>.&convert, Str;
+    is .<input><number>.&raindrop, |.<expected description>;
+    isa-ok .<input><number>.&raindrop, Str;
   }
 }
 


### PR DESCRIPTION
`convert` as a subroutine name is too generic.