### PR TITLE
Replace `prove` with `prove6` in docs

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -18,9 +18,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 {{ with .Spec.Credits }}
 ## Source
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -3,45 +3,28 @@
 There is a Perl 6 script with the extension `.t`, which will be used to test
 your solution. You can run through the tests by using the command:
 
-`prove . --exec=perl6`
+`prove6 .`
 
 Before you start the exercise, the output will likely look something like:
 
 ```
-./hello-world.t .. 1/4 
+
 # Failed test 'Say Hi!'
-# at ./hello-world.t line 37
+# at hello-world.t line 11
 # expected: 'Hello, World!'
 #      got: (Nil)
-# Looks like you failed 1 test of 4
-./hello-world.t .. Dubious, test returned 1 (wstat 256, 0x100)
-Failed 1/4 subtests 
-
-Test Summary Report
--------------------
-./hello-world.t (Wstat: 256 Tests: 4 Failed: 1)
-  Failed test:  3
-  Non-zero exit status: 1
-Files=1, Tests=4,  1 wallclock secs ( 0.01 usr  0.00 sys +  0.50 cusr  0.04 csys =  0.55 CPU)
-Result: FAIL
+# Looks like you failed 1 test of 1
+hello-world.t .. Dubious, test returned 1
+Failed 1/1 subtests
 ```
 You will either need to modify or create a module with the extension `.pm6`, and
 write a solution to pass the tests. Once the tests are passing, the output from
 the command above will likely look something like:
 
 ```
-./hello-world.t .. ok
+hello-world.t .. ok
 All tests successful.
-Files=1, Tests=4,  1 wallclock secs ( 0.01 usr  0.00 sys +  0.49 cusr  0.06 csys =  0.56 CPU)
-Result: PASS
 ```
-
-Some exercises may have optional tests. You can test for these by adding the
-flag `-v` (for 'verbose') to the above command, like so:
-
-`prove . --exec=perl6 -v`
-
-As well as showing optional tests, it will include all of the tests that your solution currently passes.
 
 ## Stop After First Failure
 
@@ -53,11 +36,11 @@ In Linux / OS X:
 ```bash
 export PERL6_TEST_DIE_ON_FAIL=1
 # now all the follow up runs will stop at the first failure
-prove . --exec=perl6
+prove6 .
 # until we do
 unset PERL6_TEST_DIE_ON_FAIL
 # or you can use it for one run like this:
-PERL6_TEST_DIE_ON_FAIL=1 prove . --exec=perl6
+PERL6_TEST_DIE_ON_FAIL=1 prove6 .
 ```
 
 Or in Windows:
@@ -65,7 +48,7 @@ Or in Windows:
 ```
 SET PERL6_TEST_DIE_ON_FAIL=1
 REM now all the follow up runs will stop at the first failure
-prove . --exec=perl6
+prove6 .
 REM until we do
 set PERL6_TEST_DIE_ON_FAIL=
 ```

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -39,9 +39,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -21,9 +21,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -45,9 +45,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -43,9 +43,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -20,9 +20,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -42,9 +42,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -44,9 +44,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -29,9 +29,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -20,9 +20,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -60,9 +60,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -24,9 +24,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -48,9 +48,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -40,9 +40,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -50,9 +50,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -28,9 +28,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -40,9 +40,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -41,9 +41,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -78,9 +78,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -40,9 +40,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -26,9 +26,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -22,9 +22,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -42,9 +42,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -31,9 +31,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -32,9 +32,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -29,9 +29,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -56,9 +56,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -53,9 +53,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -31,9 +31,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -35,9 +35,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -26,9 +26,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -25,9 +25,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -65,9 +65,7 @@ from the module (a file with the extension `.pm6`).
 Add/modify routines in the module so that the tests will pass! You can view the
 test data by executing the command `perl6 --doc *.t` (\* being the name of the
 test suite), and run the test suite for the exercise by executing the command
-`prove . --exec=perl6` in the exercise directory.
-You can also add the `-v` flag e.g. `prove . --exec=perl6 -v` to display all
-tests, including any optional tests marked as 'TODO'.
+`prove6 .` in the exercise directory.
 
 ## Source
 


### PR DESCRIPTION
`prove6` comes with Rakudo Star, and `prove` is not always present e.g if you're on Windows and haven't installed Perl 5.