### PR TITLE
Raku name changes for LEARNING doc

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,15 +1,14 @@
-## Learning Perl 6
+## Learning Raku (formerly Perl 6)
 
-The [Resources](https://perl6.org/resources/) page on [perl6.org](https://perl6.org/) contains a 'For Newcomers' section with a selection of useful material to get you up and running.
+The [Resources](https://raku.org/resources/) page on [raku.org](https://raku.org/) contains a 'For Newcomers' section with a selection of useful material to get you up and running.
 
 * [Perl 6 Introduction](http://perl6intro.com/)
 * [Learn Perl 6 in Y minutes](https://learnxinyminutes.com/docs/perl6/)
 * [Perl 6 tutorials](https://github.com/perlpilot/perl6-docs)
-* [SixFix](http://sixfix.nigelhamilton.com/) a weekly dose of Perl 6 delivered by email
 
 ## Perl 6 from Other Languages - Nutshell
 
-* [Perl 5](https://docs.perl6.org/language/5to6-nutshell)
-* [Haskell](https://docs.perl6.org/language/haskell-to-p6)
-* [Python](https://docs.perl6.org/language/py-nutshell)
-* [Ruby](https://docs.perl6.org/language/rb-nutshell)
+* [Perl 5](https://docs.raku.org/language/5to6-nutshell)
+* [Haskell](https://docs.raku.org/language/haskell-to-p6)
+* [Python](https://docs.raku.org/language/py-nutshell)
+* [Ruby](https://docs.raku.org/language/rb-nutshell)


### PR DESCRIPTION
- Remove broken link
- update domain names for documentation to new Raku name.